### PR TITLE
Remove generated index pages and path parts from module titles

### DIFF
--- a/docs/01-introduction/_category_.json
+++ b/docs/01-introduction/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Introduction",
-  "position": 1,
-  "link": {
-    "type": "generated-index",
-    "description": "Polymesh Documents Introduction Section"
-  }
+  "position": 1
 }

--- a/docs/02-quickstart/_category_.json
+++ b/docs/02-quickstart/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Quick Start",
-  "position": 2,
-  "link": {
-    "type": "generated-index",
-    "description": "Polymesh Quick start guides"
-  }
+  "position": 2
 }

--- a/docs/03-originate/_category_.json
+++ b/docs/03-originate/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Originate an Asset",
-  "position": 3,
-  "link": {
-    "type": "generated-index",
-    "description": "Learn how an asset is originated with Polymesh"
-  }
+  "position": 3
 }

--- a/docs/04-distribute/_category_.json
+++ b/docs/04-distribute/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Distributing an Assets",
-  "position": 4,
-  "link": {
-    "type": "generated-index",
-    "description": "Learn how to distribute an asset on Polymesh"
-  }
+  "position": 4
 }

--- a/docs/05-settlement/_category_.json
+++ b/docs/05-settlement/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Settlement",
-  "position": 5,
-  "link": {
-    "type": "generated-index",
-    "description": "Learn how asset settlement works on Polymesh"
-  }
+  "position": 5
 }

--- a/docs/06-actions/_category_.json
+++ b/docs/06-actions/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Corporate Actions",
-  "position": 6,
-  "link": {
-    "type": "generated-index",
-    "description": "Learn about onchain corporate actions with Polymesh"
-  }
+  "position": 6
 }

--- a/docs/07-kyc/_category_.json
+++ b/docs/07-kyc/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "KYC and CDD on Polymesh",
-  "position": 7,
-  "link": {
-    "type": "generated-index",
-    "description": "Learn about Know Your Customer and Certified Due Dilligence capabilities of Polymesh"
-  }
+  "position": 7
 }

--- a/docs/08-resources/_category_.json
+++ b/docs/08-resources/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Resources",
-  "position": 8,
-  "link": {
-    "type": "generated-index",
-    "description": "Some useful references when working with Polymesh"
-  }
+  "position": 8
 }

--- a/docs/09-community/_category_.json
+++ b/docs/09-community/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Community",
-  "position": 9,
-  "link": {
-    "type": "generated-index",
-    "description": "Community links and Bug Bounty Program"
-  }
+  "position": 9
 }

--- a/polymesh-docs/network/_category_.json
+++ b/polymesh-docs/network/_category_.json
@@ -1,8 +1,6 @@
 {
   "label": "Network",
   "position": 2,
-  "link": {
-    "type": "generated-index",
-    "description": "This section contains information relating to Polymesh Blockchain network."
-  }
+  "collapsible": true,
+  "collapsed": false
 }

--- a/polymesh-docs/primitives/_category_.json
+++ b/polymesh-docs/primitives/_category_.json
@@ -1,8 +1,6 @@
 {
   "label": "Primitives",
   "position": 3,
-  "link": {
-    "type": "generated-index",
-    "description": "This section contains information relating to Polymesh Primitives."
-  }
+  "collapsible": true,
+  "collapsed": false
 }

--- a/sdk-docs/classes/API/Client/AccountManagement/AccountManagement.md
+++ b/sdk-docs/classes/API/Client/AccountManagement/AccountManagement.md
@@ -4,8 +4,6 @@ title: "Class: AccountManagement"
 sidebar_label: "AccountManagement"
 ---
 
-# Class: AccountManagement
-
 [api/client/AccountManagement](../../../../modules/API/Client/AccountManagement/AccountManagement.md).AccountManagement
 
 Handles functionality related to Account Management

--- a/sdk-docs/classes/API/Client/Assets/Assets.md
+++ b/sdk-docs/classes/API/Client/Assets/Assets.md
@@ -4,8 +4,6 @@ title: "Class: Assets"
 sidebar_label: "Assets"
 ---
 
-# Class: Assets
-
 [api/client/Assets](../../../../modules/API/Client/Assets/Assets.md).Assets
 
 Handles all Asset related functionality

--- a/sdk-docs/classes/API/Client/Claims/Claims.md
+++ b/sdk-docs/classes/API/Client/Claims/Claims.md
@@ -4,8 +4,6 @@ title: "Class: Claims"
 sidebar_label: "Claims"
 ---
 
-# Class: Claims
-
 [api/client/Claims](../../../../modules/API/Client/Claims/Claims.md).Claims
 
 Handles all Claims related functionality

--- a/sdk-docs/classes/API/Client/Identities/Identities.md
+++ b/sdk-docs/classes/API/Client/Identities/Identities.md
@@ -4,8 +4,6 @@ title: "Class: Identities"
 sidebar_label: "Identities"
 ---
 
-# Class: Identities
-
 [api/client/Identities](../../../../modules/API/Client/Identities/Identities.md).Identities
 
 Handles all Identity related functionality

--- a/sdk-docs/classes/API/Client/Network/Network.md
+++ b/sdk-docs/classes/API/Client/Network/Network.md
@@ -4,8 +4,6 @@ title: "Class: Network"
 sidebar_label: "Network"
 ---
 
-# Class: Network
-
 [api/client/Network](../../../../modules/API/Client/Network/Network.md).Network
 
 Handles all Network related functionality, including querying for historical events from middleware

--- a/sdk-docs/classes/API/Client/Polymesh/Polymesh.md
+++ b/sdk-docs/classes/API/Client/Polymesh/Polymesh.md
@@ -4,8 +4,6 @@ title: "Class: Polymesh"
 sidebar_label: "Polymesh"
 ---
 
-# Class: Polymesh
-
 [api/client/Polymesh](../../../../modules/API/Client/Polymesh/Polymesh.md).Polymesh
 
 Main entry point of the Polymesh SDK

--- a/sdk-docs/classes/API/Client/Settlements/Settlements.md
+++ b/sdk-docs/classes/API/Client/Settlements/Settlements.md
@@ -4,8 +4,6 @@ title: "Class: Settlements"
 sidebar_label: "Settlements"
 ---
 
-# Class: Settlements
-
 [api/client/Settlements](../../../../modules/API/Client/Settlements/Settlements.md).Settlements
 
 Handles all Settlement related functionality

--- a/sdk-docs/classes/API/Entities/Account/Account.md
+++ b/sdk-docs/classes/API/Entities/Account/Account.md
@@ -4,8 +4,6 @@ title: "Class: Account"
 sidebar_label: "Account"
 ---
 
-# Class: Account
-
 [api/entities/Account](../../../../modules/API/Entities/Account/Account.md).Account
 
 Represents an Account in the Polymesh blockchain. Accounts can hold POLYX, control Identities and vote on proposals (among other things)

--- a/sdk-docs/classes/API/Entities/Asset/Asset.md
+++ b/sdk-docs/classes/API/Entities/Asset/Asset.md
@@ -4,8 +4,6 @@ title: "Class: Asset"
 sidebar_label: "Asset"
 ---
 
-# Class: Asset
-
 [api/entities/Asset](../../../../modules/API/Entities/Asset/Asset.md).Asset
 
 Class used to manage all Asset functionality

--- a/sdk-docs/classes/API/Entities/Asset/AssetHolders/AssetHolders.md
+++ b/sdk-docs/classes/API/Entities/Asset/AssetHolders/AssetHolders.md
@@ -4,8 +4,6 @@ title: "Class: AssetHolders"
 sidebar_label: "AssetHolders"
 ---
 
-# Class: AssetHolders
-
 [api/entities/Asset/AssetHolders](../../../../../modules/API/Entities/Asset/AssetHolders/AssetHolders.md).AssetHolders
 
 Handles all Asset Holders related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Checkpoints/Checkpoints.md
+++ b/sdk-docs/classes/API/Entities/Asset/Checkpoints/Checkpoints.md
@@ -4,8 +4,6 @@ title: "Class: Checkpoints"
 sidebar_label: "Checkpoints"
 ---
 
-# Class: Checkpoints
-
 [api/entities/Asset/Checkpoints](../../../../../modules/API/Entities/Asset/Checkpoints/Checkpoints.md).Checkpoints
 
 Handles all Asset Checkpoints related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Checkpoints/Schedules/Schedules.md
+++ b/sdk-docs/classes/API/Entities/Asset/Checkpoints/Schedules/Schedules.md
@@ -4,8 +4,6 @@ title: "Class: Schedules"
 sidebar_label: "Schedules"
 ---
 
-# Class: Schedules
-
 [api/entities/Asset/Checkpoints/Schedules](../../../../../../modules/API/Entities/Asset/Checkpoints/Schedules/Schedules.md).Schedules
 
 Handles all Asset Checkpoint Schedules related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Compliance/Compliance.md
+++ b/sdk-docs/classes/API/Entities/Asset/Compliance/Compliance.md
@@ -4,8 +4,6 @@ title: "Class: Compliance"
 sidebar_label: "Compliance"
 ---
 
-# Class: Compliance
-
 [api/entities/Asset/Compliance](../../../../../modules/API/Entities/Asset/Compliance/Compliance.md).Compliance
 
 Handles all Asset Compliance related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Compliance/Requirements/Requirements.md
+++ b/sdk-docs/classes/API/Entities/Asset/Compliance/Requirements/Requirements.md
@@ -4,8 +4,6 @@ title: "Class: Requirements"
 sidebar_label: "Requirements"
 ---
 
-# Class: Requirements
-
 [api/entities/Asset/Compliance/Requirements](../../../../../../modules/API/Entities/Asset/Compliance/Requirements/Requirements.md).Requirements
 
 Handles all Asset Compliance Requirements related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Compliance/TrustedClaimIssuers/TrustedClaimIssuers.md
+++ b/sdk-docs/classes/API/Entities/Asset/Compliance/TrustedClaimIssuers/TrustedClaimIssuers.md
@@ -4,8 +4,6 @@ title: "Class: TrustedClaimIssuers"
 sidebar_label: "TrustedClaimIssuers"
 ---
 
-# Class: TrustedClaimIssuers
-
 [api/entities/Asset/Compliance/TrustedClaimIssuers](../../../../../../modules/API/Entities/Asset/Compliance/TrustedClaimIssuers/TrustedClaimIssuers.md).TrustedClaimIssuers
 
 Handles all Asset Default Trusted Claim Issuers related functionality

--- a/sdk-docs/classes/API/Entities/Asset/CorporateActions/CorporateActions.md
+++ b/sdk-docs/classes/API/Entities/Asset/CorporateActions/CorporateActions.md
@@ -4,8 +4,6 @@ title: "Class: CorporateActions"
 sidebar_label: "CorporateActions"
 ---
 
-# Class: CorporateActions
-
 [api/entities/Asset/CorporateActions](../../../../../modules/API/Entities/Asset/CorporateActions/CorporateActions.md).CorporateActions
 
 Handles all Asset Corporate Actions related functionality

--- a/sdk-docs/classes/API/Entities/Asset/CorporateActions/Distributions/Distributions.md
+++ b/sdk-docs/classes/API/Entities/Asset/CorporateActions/Distributions/Distributions.md
@@ -4,8 +4,6 @@ title: "Class: Distributions"
 sidebar_label: "Distributions"
 ---
 
-# Class: Distributions
-
 [api/entities/Asset/CorporateActions/Distributions](../../../../../../modules/API/Entities/Asset/CorporateActions/Distributions/Distributions.md).Distributions
 
 Handles all Asset Distributions related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Documents/Documents.md
+++ b/sdk-docs/classes/API/Entities/Asset/Documents/Documents.md
@@ -4,8 +4,6 @@ title: "Class: Documents"
 sidebar_label: "Documents"
 ---
 
-# Class: Documents
-
 [api/entities/Asset/Documents](../../../../../modules/API/Entities/Asset/Documents/Documents.md).Documents
 
 Handles all Asset Document related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Issuance/Issuance.md
+++ b/sdk-docs/classes/API/Entities/Asset/Issuance/Issuance.md
@@ -4,8 +4,6 @@ title: "Class: Issuance"
 sidebar_label: "Issuance"
 ---
 
-# Class: Issuance
-
 [api/entities/Asset/Issuance](../../../../../modules/API/Entities/Asset/Issuance/Issuance.md).Issuance
 
 Handles all Asset Issuance related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Metadata/Metadata.md
+++ b/sdk-docs/classes/API/Entities/Asset/Metadata/Metadata.md
@@ -4,8 +4,6 @@ title: "Class: Metadata"
 sidebar_label: "Metadata"
 ---
 
-# Class: Metadata
-
 [api/entities/Asset/Metadata](../../../../../modules/API/Entities/Asset/Metadata/Metadata.md).Metadata
 
 Handles all Asset Metadata related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Offerings/Offerings.md
+++ b/sdk-docs/classes/API/Entities/Asset/Offerings/Offerings.md
@@ -4,8 +4,6 @@ title: "Class: Offerings"
 sidebar_label: "Offerings"
 ---
 
-# Class: Offerings
-
 [api/entities/Asset/Offerings](../../../../../modules/API/Entities/Asset/Offerings/Offerings.md).Offerings
 
 Handles all Asset Offering related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Permissions/Permissions.md
+++ b/sdk-docs/classes/API/Entities/Asset/Permissions/Permissions.md
@@ -4,8 +4,6 @@ title: "Class: Permissions"
 sidebar_label: "Permissions"
 ---
 
-# Class: Permissions
-
 [api/entities/Asset/Permissions](../../../../../modules/API/Entities/Asset/Permissions/Permissions.md).Permissions
 
 Handles all Asset Permissions related functionality

--- a/sdk-docs/classes/API/Entities/Asset/Settlements/Settlements.md
+++ b/sdk-docs/classes/API/Entities/Asset/Settlements/Settlements.md
@@ -4,8 +4,6 @@ title: "Class: Settlements"
 sidebar_label: "Settlements"
 ---
 
-# Class: Settlements
-
 [api/entities/Asset/Settlements](../../../../../modules/API/Entities/Asset/Settlements/Settlements.md).Settlements
 
 Handles all Asset Settlements related functionality

--- a/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/ClaimCount/ClaimCount.md
+++ b/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/ClaimCount/ClaimCount.md
@@ -4,8 +4,6 @@ title: "Class: ClaimCount"
 sidebar_label: "ClaimCount"
 ---
 
-# Class: ClaimCount
-
 [api/entities/Asset/TransferRestrictions/ClaimCount](../../../../../../modules/API/Entities/Asset/TransferRestrictions/ClaimCount/ClaimCount.md).ClaimCount
 
 Handles all Claim Count Transfer Restriction related functionality

--- a/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/ClaimPercentage/ClaimPercentage.md
+++ b/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/ClaimPercentage/ClaimPercentage.md
@@ -4,8 +4,6 @@ title: "Class: ClaimPercentage"
 sidebar_label: "ClaimPercentage"
 ---
 
-# Class: ClaimPercentage
-
 [api/entities/Asset/TransferRestrictions/ClaimPercentage](../../../../../../modules/API/Entities/Asset/TransferRestrictions/ClaimPercentage/ClaimPercentage.md).ClaimPercentage
 
 Handles all Claim Percentage Transfer Restriction related functionality

--- a/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/Count/Count.md
+++ b/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/Count/Count.md
@@ -4,8 +4,6 @@ title: "Class: Count"
 sidebar_label: "Count"
 ---
 
-# Class: Count
-
 [api/entities/Asset/TransferRestrictions/Count](../../../../../../modules/API/Entities/Asset/TransferRestrictions/Count/Count.md).Count
 
 Handles all Count Transfer Restriction related functionality

--- a/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/Percentage/Percentage.md
+++ b/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/Percentage/Percentage.md
@@ -4,8 +4,6 @@ title: "Class: Percentage"
 sidebar_label: "Percentage"
 ---
 
-# Class: Percentage
-
 [api/entities/Asset/TransferRestrictions/Percentage](../../../../../../modules/API/Entities/Asset/TransferRestrictions/Percentage/Percentage.md).Percentage
 
 Handles all Percentage Transfer Restriction related functionality

--- a/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/TransferRestrictionBase/TransferRestrictionBase.md
+++ b/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/TransferRestrictionBase/TransferRestrictionBase.md
@@ -4,8 +4,6 @@ title: "Class: TransferRestrictionBase<T>"
 sidebar_label: "TransferRestrictionBase"
 ---
 
-# Class: TransferRestrictionBase<T\>
-
 [api/entities/Asset/TransferRestrictions/TransferRestrictionBase](../../../../../../modules/API/Entities/Asset/TransferRestrictions/TransferRestrictionBase/TransferRestrictionBase.md).TransferRestrictionBase
 
 Base class for managing Transfer Restrictions

--- a/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/TransferRestrictions.md
+++ b/sdk-docs/classes/API/Entities/Asset/TransferRestrictions/TransferRestrictions.md
@@ -4,8 +4,6 @@ title: "Class: TransferRestrictions"
 sidebar_label: "TransferRestrictions"
 ---
 
-# Class: TransferRestrictions
-
 [api/entities/Asset/TransferRestrictions](../../../../../modules/API/Entities/Asset/TransferRestrictions/TransferRestrictions.md).TransferRestrictions
 
 Handles all Asset Transfer Restrictions related functionality

--- a/sdk-docs/classes/API/Entities/AuthorizationRequest/AuthorizationRequest.md
+++ b/sdk-docs/classes/API/Entities/AuthorizationRequest/AuthorizationRequest.md
@@ -4,8 +4,6 @@ title: "Class: AuthorizationRequest"
 sidebar_label: "AuthorizationRequest"
 ---
 
-# Class: AuthorizationRequest
-
 [api/entities/AuthorizationRequest](../../../../modules/API/Entities/AuthorizationRequest/AuthorizationRequest.md).AuthorizationRequest
 
 Represents a request made by an Identity to another Identity (or Account) for some sort of authorization. This has multiple uses. For example, if Alice

--- a/sdk-docs/classes/API/Entities/Checkpoint/Checkpoint.md
+++ b/sdk-docs/classes/API/Entities/Checkpoint/Checkpoint.md
@@ -4,8 +4,6 @@ title: "Class: Checkpoint"
 sidebar_label: "Checkpoint"
 ---
 
-# Class: Checkpoint
-
 [api/entities/Checkpoint](../../../../modules/API/Entities/Checkpoint/Checkpoint.md).Checkpoint
 
 Represents a snapshot of the Asset's holders and their respective balances

--- a/sdk-docs/classes/API/Entities/CheckpointSchedule/CheckpointSchedule.md
+++ b/sdk-docs/classes/API/Entities/CheckpointSchedule/CheckpointSchedule.md
@@ -4,8 +4,6 @@ title: "Class: CheckpointSchedule"
 sidebar_label: "CheckpointSchedule"
 ---
 
-# Class: CheckpointSchedule
-
 [api/entities/CheckpointSchedule](../../../../modules/API/Entities/CheckpointSchedule/CheckpointSchedule.md).CheckpointSchedule
 
 Represents a Checkpoint Schedule for an Asset. Schedules can be set up to create Checkpoints at regular intervals

--- a/sdk-docs/classes/API/Entities/Common/Namespaces/Authorizations/Authorizations.md
+++ b/sdk-docs/classes/API/Entities/Common/Namespaces/Authorizations/Authorizations.md
@@ -4,8 +4,6 @@ title: "Class: Authorizations<Parent>"
 sidebar_label: "Authorizations"
 ---
 
-# Class: Authorizations<Parent\>
-
 [api/entities/common/namespaces/Authorizations](../../../../../../modules/API/Entities/Common/Namespaces/Authorizations/Authorizations.md).Authorizations
 
 Handles all Authorization related functionality

--- a/sdk-docs/classes/API/Entities/CorporateAction/CorporateAction.md
+++ b/sdk-docs/classes/API/Entities/CorporateAction/CorporateAction.md
@@ -4,8 +4,6 @@ title: "Class: CorporateAction"
 sidebar_label: "CorporateAction"
 ---
 
-# Class: CorporateAction
-
 [api/entities/CorporateAction](../../../../modules/API/Entities/CorporateAction/CorporateAction.md).CorporateAction
 
 Represents an action initiated by the issuer of an Asset which may affect the positions of

--- a/sdk-docs/classes/API/Entities/CorporateActionBase/CorporateActionBase.md
+++ b/sdk-docs/classes/API/Entities/CorporateActionBase/CorporateActionBase.md
@@ -4,8 +4,6 @@ title: "Class: CorporateActionBase"
 sidebar_label: "CorporateActionBase"
 ---
 
-# Class: CorporateActionBase
-
 [api/entities/CorporateActionBase](../../../../modules/API/Entities/CorporateActionBase/CorporateActionBase.md).CorporateActionBase
 
 Represents an action initiated by the issuer of an Asset which may affect the positions of

--- a/sdk-docs/classes/API/Entities/CustomPermissionGroup/CustomPermissionGroup.md
+++ b/sdk-docs/classes/API/Entities/CustomPermissionGroup/CustomPermissionGroup.md
@@ -4,8 +4,6 @@ title: "Class: CustomPermissionGroup"
 sidebar_label: "CustomPermissionGroup"
 ---
 
-# Class: CustomPermissionGroup
-
 [api/entities/CustomPermissionGroup](../../../../modules/API/Entities/CustomPermissionGroup/CustomPermissionGroup.md).CustomPermissionGroup
 
 Represents a group of custom permissions for an Asset

--- a/sdk-docs/classes/API/Entities/DefaultPortfolio/DefaultPortfolio.md
+++ b/sdk-docs/classes/API/Entities/DefaultPortfolio/DefaultPortfolio.md
@@ -4,8 +4,6 @@ title: "Class: DefaultPortfolio"
 sidebar_label: "DefaultPortfolio"
 ---
 
-# Class: DefaultPortfolio
-
 [api/entities/DefaultPortfolio](../../../../modules/API/Entities/DefaultPortfolio/DefaultPortfolio.md).DefaultPortfolio
 
 Represents the default Portfolio for an Identity

--- a/sdk-docs/classes/API/Entities/DefaultTrustedClaimIssuer/DefaultTrustedClaimIssuer.md
+++ b/sdk-docs/classes/API/Entities/DefaultTrustedClaimIssuer/DefaultTrustedClaimIssuer.md
@@ -4,8 +4,6 @@ title: "Class: DefaultTrustedClaimIssuer"
 sidebar_label: "DefaultTrustedClaimIssuer"
 ---
 
-# Class: DefaultTrustedClaimIssuer
-
 [api/entities/DefaultTrustedClaimIssuer](../../../../modules/API/Entities/DefaultTrustedClaimIssuer/DefaultTrustedClaimIssuer.md).DefaultTrustedClaimIssuer
 
 Represents a default trusted claim issuer for a specific Asset in the Polymesh blockchain

--- a/sdk-docs/classes/API/Entities/DividendDistribution/DividendDistribution.md
+++ b/sdk-docs/classes/API/Entities/DividendDistribution/DividendDistribution.md
@@ -4,8 +4,6 @@ title: "Class: DividendDistribution"
 sidebar_label: "DividendDistribution"
 ---
 
-# Class: DividendDistribution
-
 [api/entities/DividendDistribution](../../../../modules/API/Entities/DividendDistribution/DividendDistribution.md).DividendDistribution
 
 Represents a Corporate Action via which an Asset issuer wishes to distribute dividends

--- a/sdk-docs/classes/API/Entities/Entity/Entity.md
+++ b/sdk-docs/classes/API/Entities/Entity/Entity.md
@@ -4,8 +4,6 @@ title: "Class: Entity<UniqueIdentifiers, HumanReadable>"
 sidebar_label: "Entity"
 ---
 
-# Class: Entity<UniqueIdentifiers, HumanReadable\>
-
 [api/entities/Entity](../../../../modules/API/Entities/Entity/Entity.md).Entity
 
 Represents an object or resource in the Polymesh Ecosystem with its own set of properties and functionality

--- a/sdk-docs/classes/API/Entities/Identity/AssetPermissions/AssetPermissions.md
+++ b/sdk-docs/classes/API/Entities/Identity/AssetPermissions/AssetPermissions.md
@@ -4,8 +4,6 @@ title: "Class: AssetPermissions"
 sidebar_label: "AssetPermissions"
 ---
 
-# Class: AssetPermissions
-
 [api/entities/Identity/AssetPermissions](../../../../../modules/API/Entities/Identity/AssetPermissions/AssetPermissions.md).AssetPermissions
 
 Handles all Asset Permissions (External Agents) related functionality on the Identity side

--- a/sdk-docs/classes/API/Entities/Identity/Identity.md
+++ b/sdk-docs/classes/API/Entities/Identity/Identity.md
@@ -4,8 +4,6 @@ title: "Class: Identity"
 sidebar_label: "Identity"
 ---
 
-# Class: Identity
-
 [api/entities/Identity](../../../../modules/API/Entities/Identity/Identity.md).Identity
 
 Represents an Identity in the Polymesh blockchain

--- a/sdk-docs/classes/API/Entities/Identity/IdentityAuthorizations/IdentityAuthorizations.md
+++ b/sdk-docs/classes/API/Entities/Identity/IdentityAuthorizations/IdentityAuthorizations.md
@@ -4,8 +4,6 @@ title: "Class: IdentityAuthorizations"
 sidebar_label: "IdentityAuthorizations"
 ---
 
-# Class: IdentityAuthorizations
-
 [api/entities/Identity/IdentityAuthorizations](../../../../../modules/API/Entities/Identity/IdentityAuthorizations/IdentityAuthorizations.md).IdentityAuthorizations
 
 Handles all Identity Authorization related functionality

--- a/sdk-docs/classes/API/Entities/Identity/Portfolios/Portfolios.md
+++ b/sdk-docs/classes/API/Entities/Identity/Portfolios/Portfolios.md
@@ -4,8 +4,6 @@ title: "Class: Portfolios"
 sidebar_label: "Portfolios"
 ---
 
-# Class: Portfolios
-
 [api/entities/Identity/Portfolios](../../../../../modules/API/Entities/Identity/Portfolios/Portfolios.md).Portfolios
 
 Handles all Portfolio related functionality on the Identity side

--- a/sdk-docs/classes/API/Entities/Instruction/Instruction.md
+++ b/sdk-docs/classes/API/Entities/Instruction/Instruction.md
@@ -4,8 +4,6 @@ title: "Class: Instruction"
 sidebar_label: "Instruction"
 ---
 
-# Class: Instruction
-
 [api/entities/Instruction](../../../../modules/API/Entities/Instruction/Instruction.md).Instruction
 
 Represents a settlement Instruction to be executed on a certain Venue

--- a/sdk-docs/classes/API/Entities/KnownPermissionGroup/KnownPermissionGroup.md
+++ b/sdk-docs/classes/API/Entities/KnownPermissionGroup/KnownPermissionGroup.md
@@ -4,8 +4,6 @@ title: "Class: KnownPermissionGroup"
 sidebar_label: "KnownPermissionGroup"
 ---
 
-# Class: KnownPermissionGroup
-
 [api/entities/KnownPermissionGroup](../../../../modules/API/Entities/KnownPermissionGroup/KnownPermissionGroup.md).KnownPermissionGroup
 
 Represents a pre-defined group of permissions for an Asset

--- a/sdk-docs/classes/API/Entities/MetadataEntry/MetadataEntry.md
+++ b/sdk-docs/classes/API/Entities/MetadataEntry/MetadataEntry.md
@@ -4,8 +4,6 @@ title: "Class: MetadataEntry"
 sidebar_label: "MetadataEntry"
 ---
 
-# Class: MetadataEntry
-
 [api/entities/MetadataEntry](../../../../modules/API/Entities/MetadataEntry/MetadataEntry.md).MetadataEntry
 
 Represents an Asset MetadataEntry in the Polymesh blockchain

--- a/sdk-docs/classes/API/Entities/MultiSig/MultiSig.md
+++ b/sdk-docs/classes/API/Entities/MultiSig/MultiSig.md
@@ -4,8 +4,6 @@ title: "Class: MultiSig"
 sidebar_label: "MultiSig"
 ---
 
-# Class: MultiSig
-
 [api/entities/MultiSig](../../../../modules/API/Entities/MultiSig/MultiSig.md).MultiSig
 
 Represents a MultiSig Account. A MultiSig Account is composed of one or more signing Accounts. In order to submit a transaction, a specific amount of those signing Accounts must approve it first

--- a/sdk-docs/classes/API/Entities/MultiSigProposal/MultiSigProposal.md
+++ b/sdk-docs/classes/API/Entities/MultiSigProposal/MultiSigProposal.md
@@ -4,8 +4,6 @@ title: "Class: MultiSigProposal"
 sidebar_label: "MultiSigProposal"
 ---
 
-# Class: MultiSigProposal
-
 [api/entities/MultiSigProposal](../../../../modules/API/Entities/MultiSigProposal/MultiSigProposal.md).MultiSigProposal
 
 A proposal for a MultiSig transaction. This is a wrapper around an extrinsic that will be executed when the amount of approvals reaches the signature threshold set on the MultiSig Account

--- a/sdk-docs/classes/API/Entities/NumberedPortfolio/NumberedPortfolio.md
+++ b/sdk-docs/classes/API/Entities/NumberedPortfolio/NumberedPortfolio.md
@@ -4,8 +4,6 @@ title: "Class: NumberedPortfolio"
 sidebar_label: "NumberedPortfolio"
 ---
 
-# Class: NumberedPortfolio
-
 [api/entities/NumberedPortfolio](../../../../modules/API/Entities/NumberedPortfolio/NumberedPortfolio.md).NumberedPortfolio
 
 Represents a numbered (non-default) Portfolio for an Identity

--- a/sdk-docs/classes/API/Entities/Offering/Offering.md
+++ b/sdk-docs/classes/API/Entities/Offering/Offering.md
@@ -4,8 +4,6 @@ title: "Class: Offering"
 sidebar_label: "Offering"
 ---
 
-# Class: Offering
-
 [api/entities/Offering](../../../../modules/API/Entities/Offering/Offering.md).Offering
 
 Represents an Asset Offering in the Polymesh blockchain

--- a/sdk-docs/classes/API/Entities/PermissionGroup/PermissionGroup.md
+++ b/sdk-docs/classes/API/Entities/PermissionGroup/PermissionGroup.md
@@ -4,8 +4,6 @@ title: "Class: PermissionGroup"
 sidebar_label: "PermissionGroup"
 ---
 
-# Class: PermissionGroup
-
 [api/entities/PermissionGroup](../../../../modules/API/Entities/PermissionGroup/PermissionGroup.md).PermissionGroup
 
 Represents a group of permissions for an Asset

--- a/sdk-docs/classes/API/Entities/Portfolio/Portfolio.md
+++ b/sdk-docs/classes/API/Entities/Portfolio/Portfolio.md
@@ -4,8 +4,6 @@ title: "Class: Portfolio"
 sidebar_label: "Portfolio"
 ---
 
-# Class: Portfolio
-
 [api/entities/Portfolio](../../../../modules/API/Entities/Portfolio/Portfolio.md).Portfolio
 
 Represents a base Portfolio for a specific Identity in the Polymesh blockchain

--- a/sdk-docs/classes/API/Entities/Subsidies/Subsidies.md
+++ b/sdk-docs/classes/API/Entities/Subsidies/Subsidies.md
@@ -4,8 +4,6 @@ title: "Class: Subsidies"
 sidebar_label: "Subsidies"
 ---
 
-# Class: Subsidies
-
 [api/entities/Subsidies](../../../../modules/API/Entities/Subsidies/Subsidies.md).Subsidies
 
 Handles all Account Subsidies related functionality

--- a/sdk-docs/classes/API/Entities/Subsidy/Subsidy.md
+++ b/sdk-docs/classes/API/Entities/Subsidy/Subsidy.md
@@ -4,8 +4,6 @@ title: "Class: Subsidy"
 sidebar_label: "Subsidy"
 ---
 
-# Class: Subsidy
-
 [api/entities/Subsidy](../../../../modules/API/Entities/Subsidy/Subsidy.md).Subsidy
 
 Represents a Subsidy relationship on chain

--- a/sdk-docs/classes/API/Entities/TickerReservation/TickerReservation.md
+++ b/sdk-docs/classes/API/Entities/TickerReservation/TickerReservation.md
@@ -4,8 +4,6 @@ title: "Class: TickerReservation"
 sidebar_label: "TickerReservation"
 ---
 
-# Class: TickerReservation
-
 [api/entities/TickerReservation](../../../../modules/API/Entities/TickerReservation/TickerReservation.md).TickerReservation
 
 Represents a reserved Asset symbol in the Polymesh blockchain. Ticker reservations expire

--- a/sdk-docs/classes/API/Entities/Venue/Venue.md
+++ b/sdk-docs/classes/API/Entities/Venue/Venue.md
@@ -4,8 +4,6 @@ title: "Class: Venue"
 sidebar_label: "Venue"
 ---
 
-# Class: Venue
-
 [api/entities/Venue](../../../../modules/API/Entities/Venue/Venue.md).Venue
 
 Represents a Venue through which settlements are handled

--- a/sdk-docs/classes/Base/PolymeshError/PolymeshError.md
+++ b/sdk-docs/classes/Base/PolymeshError/PolymeshError.md
@@ -4,8 +4,6 @@ title: "Class: PolymeshError"
 sidebar_label: "PolymeshError"
 ---
 
-# Class: PolymeshError
-
 [base/PolymeshError](../../../modules/Base/PolymeshError/PolymeshError.md).PolymeshError
 
 Wraps an error to give more information about its type

--- a/sdk-docs/classes/Base/PolymeshTransaction/PolymeshTransaction.md
+++ b/sdk-docs/classes/Base/PolymeshTransaction/PolymeshTransaction.md
@@ -4,8 +4,6 @@ title: "Class: PolymeshTransaction<ReturnValue, TransformedReturnValue, Args>"
 sidebar_label: "PolymeshTransaction"
 ---
 
-# Class: PolymeshTransaction<ReturnValue, TransformedReturnValue, Args\>
-
 [base/PolymeshTransaction](../../../modules/Base/PolymeshTransaction/PolymeshTransaction.md).PolymeshTransaction
 
 Wrapper class for a Polymesh Transaction

--- a/sdk-docs/classes/Base/PolymeshTransactionBase/PolymeshTransactionBase.md
+++ b/sdk-docs/classes/Base/PolymeshTransactionBase/PolymeshTransactionBase.md
@@ -4,8 +4,6 @@ title: "Class: PolymeshTransactionBase<ReturnValue, TransformedReturnValue>"
 sidebar_label: "PolymeshTransactionBase"
 ---
 
-# Class: PolymeshTransactionBase<ReturnValue, TransformedReturnValue\>
-
 [base/PolymeshTransactionBase](../../../modules/Base/PolymeshTransactionBase/PolymeshTransactionBase.md).PolymeshTransactionBase
 
 Wrapper class for a Polymesh Transaction

--- a/sdk-docs/classes/Base/PolymeshTransactionBatch/PolymeshTransactionBatch.md
+++ b/sdk-docs/classes/Base/PolymeshTransactionBatch/PolymeshTransactionBatch.md
@@ -4,8 +4,6 @@ title: "Class: PolymeshTransactionBatch<ReturnValue, TransformedReturnValue, Arg
 sidebar_label: "PolymeshTransactionBatch"
 ---
 
-# Class: PolymeshTransactionBatch<ReturnValue, TransformedReturnValue, Args\>
-
 [base/PolymeshTransactionBatch](../../../modules/Base/PolymeshTransactionBatch/PolymeshTransactionBatch.md).PolymeshTransactionBatch
 
 Wrapper class for a batch of Polymesh Transactions

--- a/sdk-docs/enums/API/Entities/Asset/Checkpoints/Types/CaCheckpointType/CaCheckpointType.md
+++ b/sdk-docs/enums/API/Entities/Asset/Checkpoints/Types/CaCheckpointType/CaCheckpointType.md
@@ -4,8 +4,6 @@ title: "Enumeration: CaCheckpointType"
 sidebar_label: "CaCheckpointType"
 ---
 
-# Enumeration: CaCheckpointType
-
 [api/entities/Asset/Checkpoints/types](../../../../../../../modules/API/Entities/Asset/Checkpoints/Types/Types.md).CaCheckpointType
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/CorporateActionBase/Types/CorporateActionKind/CorporateActionKind.md
+++ b/sdk-docs/enums/API/Entities/CorporateActionBase/Types/CorporateActionKind/CorporateActionKind.md
@@ -4,8 +4,6 @@ title: "Enumeration: CorporateActionKind"
 sidebar_label: "CorporateActionKind"
 ---
 
-# Enumeration: CorporateActionKind
-
 [api/entities/CorporateActionBase/types](../../../../../../modules/API/Entities/CorporateActionBase/Types/Types.md).CorporateActionKind
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/CorporateActionBase/Types/TargetTreatment/TargetTreatment.md
+++ b/sdk-docs/enums/API/Entities/CorporateActionBase/Types/TargetTreatment/TargetTreatment.md
@@ -4,8 +4,6 @@ title: "Enumeration: TargetTreatment"
 sidebar_label: "TargetTreatment"
 ---
 
-# Enumeration: TargetTreatment
-
 [api/entities/CorporateActionBase/types](../../../../../../modules/API/Entities/CorporateActionBase/Types/Types.md).TargetTreatment
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/Instruction/Types/AffirmationStatus/AffirmationStatus.md
+++ b/sdk-docs/enums/API/Entities/Instruction/Types/AffirmationStatus/AffirmationStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: AffirmationStatus"
 sidebar_label: "AffirmationStatus"
 ---
 
-# Enumeration: AffirmationStatus
-
 [api/entities/Instruction/types](../../../../../../modules/API/Entities/Instruction/Types/Types.md).AffirmationStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/Instruction/Types/InstructionStatus/InstructionStatus.md
+++ b/sdk-docs/enums/API/Entities/Instruction/Types/InstructionStatus/InstructionStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: InstructionStatus"
 sidebar_label: "InstructionStatus"
 ---
 
-# Enumeration: InstructionStatus
-
 [api/entities/Instruction/types](../../../../../../modules/API/Entities/Instruction/Types/Types.md).InstructionStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/Instruction/Types/InstructionType/InstructionType.md
+++ b/sdk-docs/enums/API/Entities/Instruction/Types/InstructionType/InstructionType.md
@@ -4,8 +4,6 @@ title: "Enumeration: InstructionType"
 sidebar_label: "InstructionType"
 ---
 
-# Enumeration: InstructionType
-
 [api/entities/Instruction/types](../../../../../../modules/API/Entities/Instruction/Types/Types.md).InstructionType
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/MetadataEntry/Types/MetadataLockStatus/MetadataLockStatus.md
+++ b/sdk-docs/enums/API/Entities/MetadataEntry/Types/MetadataLockStatus/MetadataLockStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: MetadataLockStatus"
 sidebar_label: "MetadataLockStatus"
 ---
 
-# Enumeration: MetadataLockStatus
-
 [api/entities/MetadataEntry/types](../../../../../../modules/API/Entities/MetadataEntry/Types/Types.md).MetadataLockStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/MetadataEntry/Types/MetadataType/MetadataType.md
+++ b/sdk-docs/enums/API/Entities/MetadataEntry/Types/MetadataType/MetadataType.md
@@ -4,8 +4,6 @@ title: "Enumeration: MetadataType"
 sidebar_label: "MetadataType"
 ---
 
-# Enumeration: MetadataType
-
 [api/entities/MetadataEntry/types](../../../../../../modules/API/Entities/MetadataEntry/Types/Types.md).MetadataType
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/MultiSigProposal/Types/ProposalStatus/ProposalStatus.md
+++ b/sdk-docs/enums/API/Entities/MultiSigProposal/Types/ProposalStatus/ProposalStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: ProposalStatus"
 sidebar_label: "ProposalStatus"
 ---
 
-# Enumeration: ProposalStatus
-
 [api/entities/MultiSigProposal/types](../../../../../../modules/API/Entities/MultiSigProposal/Types/Types.md).ProposalStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/Offering/Types/OfferingBalanceStatus/OfferingBalanceStatus.md
+++ b/sdk-docs/enums/API/Entities/Offering/Types/OfferingBalanceStatus/OfferingBalanceStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: OfferingBalanceStatus"
 sidebar_label: "OfferingBalanceStatus"
 ---
 
-# Enumeration: OfferingBalanceStatus
-
 [api/entities/Offering/types](../../../../../../modules/API/Entities/Offering/Types/Types.md).OfferingBalanceStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/Offering/Types/OfferingSaleStatus/OfferingSaleStatus.md
+++ b/sdk-docs/enums/API/Entities/Offering/Types/OfferingSaleStatus/OfferingSaleStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: OfferingSaleStatus"
 sidebar_label: "OfferingSaleStatus"
 ---
 
-# Enumeration: OfferingSaleStatus
-
 [api/entities/Offering/types](../../../../../../modules/API/Entities/Offering/Types/Types.md).OfferingSaleStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/Offering/Types/OfferingTimingStatus/OfferingTimingStatus.md
+++ b/sdk-docs/enums/API/Entities/Offering/Types/OfferingTimingStatus/OfferingTimingStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: OfferingTimingStatus"
 sidebar_label: "OfferingTimingStatus"
 ---
 
-# Enumeration: OfferingTimingStatus
-
 [api/entities/Offering/types](../../../../../../modules/API/Entities/Offering/Types/Types.md).OfferingTimingStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/TickerReservation/Types/TickerReservationStatus/TickerReservationStatus.md
+++ b/sdk-docs/enums/API/Entities/TickerReservation/Types/TickerReservationStatus/TickerReservationStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: TickerReservationStatus"
 sidebar_label: "TickerReservationStatus"
 ---
 
-# Enumeration: TickerReservationStatus
-
 [api/entities/TickerReservation/types](../../../../../../modules/API/Entities/TickerReservation/Types/Types.md).TickerReservationStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Entities/Venue/Types/VenueType/VenueType.md
+++ b/sdk-docs/enums/API/Entities/Venue/Types/VenueType/VenueType.md
@@ -4,8 +4,6 @@ title: "Enumeration: VenueType"
 sidebar_label: "VenueType"
 ---
 
-# Enumeration: VenueType
-
 [api/entities/Venue/types](../../../../../../modules/API/Entities/Venue/Types/Types.md).VenueType
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Procedures/Types/AllowanceOperation/AllowanceOperation.md
+++ b/sdk-docs/enums/API/Procedures/Types/AllowanceOperation/AllowanceOperation.md
@@ -4,8 +4,6 @@ title: "Enumeration: AllowanceOperation"
 sidebar_label: "AllowanceOperation"
 ---
 
-# Enumeration: AllowanceOperation
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AllowanceOperation
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Procedures/Types/ClaimOperation/ClaimOperation.md
+++ b/sdk-docs/enums/API/Procedures/Types/ClaimOperation/ClaimOperation.md
@@ -4,8 +4,6 @@ title: "Enumeration: ClaimOperation"
 sidebar_label: "ClaimOperation"
 ---
 
-# Enumeration: ClaimOperation
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ClaimOperation
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Procedures/Types/InstructionAffirmationOperation/InstructionAffirmationOperation.md
+++ b/sdk-docs/enums/API/Procedures/Types/InstructionAffirmationOperation/InstructionAffirmationOperation.md
@@ -4,8 +4,6 @@ title: "Enumeration: InstructionAffirmationOperation"
 sidebar_label: "InstructionAffirmationOperation"
 ---
 
-# Enumeration: InstructionAffirmationOperation
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).InstructionAffirmationOperation
 
 ## Enumeration Members

--- a/sdk-docs/enums/API/Procedures/Types/TransferRestrictionType/TransferRestrictionType.md
+++ b/sdk-docs/enums/API/Procedures/Types/TransferRestrictionType/TransferRestrictionType.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransferRestrictionType"
 sidebar_label: "TransferRestrictionType"
 ---
 
-# Enumeration: TransferRestrictionType
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).TransferRestrictionType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/AssetTx/AssetTx.md
+++ b/sdk-docs/enums/Generated/Types/AssetTx/AssetTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: AssetTx"
 sidebar_label: "AssetTx"
 ---
 
-# Enumeration: AssetTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).AssetTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/AuthorshipTx/AuthorshipTx.md
+++ b/sdk-docs/enums/Generated/Types/AuthorshipTx/AuthorshipTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: AuthorshipTx"
 sidebar_label: "AuthorshipTx"
 ---
 
-# Enumeration: AuthorshipTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).AuthorshipTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/BabeTx/BabeTx.md
+++ b/sdk-docs/enums/Generated/Types/BabeTx/BabeTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: BabeTx"
 sidebar_label: "BabeTx"
 ---
 
-# Enumeration: BabeTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).BabeTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/BalancesTx/BalancesTx.md
+++ b/sdk-docs/enums/Generated/Types/BalancesTx/BalancesTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: BalancesTx"
 sidebar_label: "BalancesTx"
 ---
 
-# Enumeration: BalancesTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).BalancesTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/BridgeTx/BridgeTx.md
+++ b/sdk-docs/enums/Generated/Types/BridgeTx/BridgeTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: BridgeTx"
 sidebar_label: "BridgeTx"
 ---
 
-# Enumeration: BridgeTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).BridgeTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/CapitalDistributionTx/CapitalDistributionTx.md
+++ b/sdk-docs/enums/Generated/Types/CapitalDistributionTx/CapitalDistributionTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: CapitalDistributionTx"
 sidebar_label: "CapitalDistributionTx"
 ---
 
-# Enumeration: CapitalDistributionTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).CapitalDistributionTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/CddServiceProvidersTx/CddServiceProvidersTx.md
+++ b/sdk-docs/enums/Generated/Types/CddServiceProvidersTx/CddServiceProvidersTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: CddServiceProvidersTx"
 sidebar_label: "CddServiceProvidersTx"
 ---
 
-# Enumeration: CddServiceProvidersTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).CddServiceProvidersTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/CheckpointTx/CheckpointTx.md
+++ b/sdk-docs/enums/Generated/Types/CheckpointTx/CheckpointTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: CheckpointTx"
 sidebar_label: "CheckpointTx"
 ---
 
-# Enumeration: CheckpointTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).CheckpointTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/CommitteeMembershipTx/CommitteeMembershipTx.md
+++ b/sdk-docs/enums/Generated/Types/CommitteeMembershipTx/CommitteeMembershipTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: CommitteeMembershipTx"
 sidebar_label: "CommitteeMembershipTx"
 ---
 
-# Enumeration: CommitteeMembershipTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).CommitteeMembershipTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/ComplianceManagerTx/ComplianceManagerTx.md
+++ b/sdk-docs/enums/Generated/Types/ComplianceManagerTx/ComplianceManagerTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: ComplianceManagerTx"
 sidebar_label: "ComplianceManagerTx"
 ---
 
-# Enumeration: ComplianceManagerTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).ComplianceManagerTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/ContractsTx/ContractsTx.md
+++ b/sdk-docs/enums/Generated/Types/ContractsTx/ContractsTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: ContractsTx"
 sidebar_label: "ContractsTx"
 ---
 
-# Enumeration: ContractsTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).ContractsTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/CorporateActionTx/CorporateActionTx.md
+++ b/sdk-docs/enums/Generated/Types/CorporateActionTx/CorporateActionTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: CorporateActionTx"
 sidebar_label: "CorporateActionTx"
 ---
 
-# Enumeration: CorporateActionTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).CorporateActionTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/CorporateBallotTx/CorporateBallotTx.md
+++ b/sdk-docs/enums/Generated/Types/CorporateBallotTx/CorporateBallotTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: CorporateBallotTx"
 sidebar_label: "CorporateBallotTx"
 ---
 
-# Enumeration: CorporateBallotTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).CorporateBallotTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/CountryCode/CountryCode.md
+++ b/sdk-docs/enums/Generated/Types/CountryCode/CountryCode.md
@@ -4,8 +4,6 @@ title: "Enumeration: CountryCode"
 sidebar_label: "CountryCode"
 ---
 
-# Enumeration: CountryCode
-
 [generated/types](../../../../modules/Generated/Types/Types.md).CountryCode
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/ExternalAgentsTx/ExternalAgentsTx.md
+++ b/sdk-docs/enums/Generated/Types/ExternalAgentsTx/ExternalAgentsTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: ExternalAgentsTx"
 sidebar_label: "ExternalAgentsTx"
 ---
 
-# Enumeration: ExternalAgentsTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).ExternalAgentsTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/GrandpaTx/GrandpaTx.md
+++ b/sdk-docs/enums/Generated/Types/GrandpaTx/GrandpaTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: GrandpaTx"
 sidebar_label: "GrandpaTx"
 ---
 
-# Enumeration: GrandpaTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).GrandpaTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/IdentityTx/IdentityTx.md
+++ b/sdk-docs/enums/Generated/Types/IdentityTx/IdentityTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: IdentityTx"
 sidebar_label: "IdentityTx"
 ---
 
-# Enumeration: IdentityTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).IdentityTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/ImOnlineTx/ImOnlineTx.md
+++ b/sdk-docs/enums/Generated/Types/ImOnlineTx/ImOnlineTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: ImOnlineTx"
 sidebar_label: "ImOnlineTx"
 ---
 
-# Enumeration: ImOnlineTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).ImOnlineTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/IndicesTx/IndicesTx.md
+++ b/sdk-docs/enums/Generated/Types/IndicesTx/IndicesTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: IndicesTx"
 sidebar_label: "IndicesTx"
 ---
 
-# Enumeration: IndicesTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).IndicesTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/ModuleName/ModuleName.md
+++ b/sdk-docs/enums/Generated/Types/ModuleName/ModuleName.md
@@ -4,8 +4,6 @@ title: "Enumeration: ModuleName"
 sidebar_label: "ModuleName"
 ---
 
-# Enumeration: ModuleName
-
 [generated/types](../../../../modules/Generated/Types/Types.md).ModuleName
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/MultiSigTx/MultiSigTx.md
+++ b/sdk-docs/enums/Generated/Types/MultiSigTx/MultiSigTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: MultiSigTx"
 sidebar_label: "MultiSigTx"
 ---
 
-# Enumeration: MultiSigTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).MultiSigTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/PipsTx/PipsTx.md
+++ b/sdk-docs/enums/Generated/Types/PipsTx/PipsTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: PipsTx"
 sidebar_label: "PipsTx"
 ---
 
-# Enumeration: PipsTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).PipsTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/PolymeshCommitteeTx/PolymeshCommitteeTx.md
+++ b/sdk-docs/enums/Generated/Types/PolymeshCommitteeTx/PolymeshCommitteeTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: PolymeshCommitteeTx"
 sidebar_label: "PolymeshCommitteeTx"
 ---
 
-# Enumeration: PolymeshCommitteeTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).PolymeshCommitteeTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/PolymeshContractsTx/PolymeshContractsTx.md
+++ b/sdk-docs/enums/Generated/Types/PolymeshContractsTx/PolymeshContractsTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: PolymeshContractsTx"
 sidebar_label: "PolymeshContractsTx"
 ---
 
-# Enumeration: PolymeshContractsTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).PolymeshContractsTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/PortfolioTx/PortfolioTx.md
+++ b/sdk-docs/enums/Generated/Types/PortfolioTx/PortfolioTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: PortfolioTx"
 sidebar_label: "PortfolioTx"
 ---
 
-# Enumeration: PortfolioTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).PortfolioTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/PreimageTx/PreimageTx.md
+++ b/sdk-docs/enums/Generated/Types/PreimageTx/PreimageTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: PreimageTx"
 sidebar_label: "PreimageTx"
 ---
 
-# Enumeration: PreimageTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).PreimageTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/ProtocolFeeTx/ProtocolFeeTx.md
+++ b/sdk-docs/enums/Generated/Types/ProtocolFeeTx/ProtocolFeeTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: ProtocolFeeTx"
 sidebar_label: "ProtocolFeeTx"
 ---
 
-# Enumeration: ProtocolFeeTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).ProtocolFeeTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/RelayerTx/RelayerTx.md
+++ b/sdk-docs/enums/Generated/Types/RelayerTx/RelayerTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: RelayerTx"
 sidebar_label: "RelayerTx"
 ---
 
-# Enumeration: RelayerTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).RelayerTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/RewardsTx/RewardsTx.md
+++ b/sdk-docs/enums/Generated/Types/RewardsTx/RewardsTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: RewardsTx"
 sidebar_label: "RewardsTx"
 ---
 
-# Enumeration: RewardsTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).RewardsTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/SchedulerTx/SchedulerTx.md
+++ b/sdk-docs/enums/Generated/Types/SchedulerTx/SchedulerTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: SchedulerTx"
 sidebar_label: "SchedulerTx"
 ---
 
-# Enumeration: SchedulerTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).SchedulerTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/SessionTx/SessionTx.md
+++ b/sdk-docs/enums/Generated/Types/SessionTx/SessionTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: SessionTx"
 sidebar_label: "SessionTx"
 ---
 
-# Enumeration: SessionTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).SessionTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/SettlementTx/SettlementTx.md
+++ b/sdk-docs/enums/Generated/Types/SettlementTx/SettlementTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: SettlementTx"
 sidebar_label: "SettlementTx"
 ---
 
-# Enumeration: SettlementTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).SettlementTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/StakingTx/StakingTx.md
+++ b/sdk-docs/enums/Generated/Types/StakingTx/StakingTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: StakingTx"
 sidebar_label: "StakingTx"
 ---
 
-# Enumeration: StakingTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).StakingTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/StatisticsTx/StatisticsTx.md
+++ b/sdk-docs/enums/Generated/Types/StatisticsTx/StatisticsTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: StatisticsTx"
 sidebar_label: "StatisticsTx"
 ---
 
-# Enumeration: StatisticsTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).StatisticsTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/StoTx/StoTx.md
+++ b/sdk-docs/enums/Generated/Types/StoTx/StoTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: StoTx"
 sidebar_label: "StoTx"
 ---
 
-# Enumeration: StoTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).StoTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/SudoTx/SudoTx.md
+++ b/sdk-docs/enums/Generated/Types/SudoTx/SudoTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: SudoTx"
 sidebar_label: "SudoTx"
 ---
 
-# Enumeration: SudoTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).SudoTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/SystemTx/SystemTx.md
+++ b/sdk-docs/enums/Generated/Types/SystemTx/SystemTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: SystemTx"
 sidebar_label: "SystemTx"
 ---
 
-# Enumeration: SystemTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).SystemTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/TechnicalCommitteeMembershipTx/TechnicalCommitteeMembershipTx.md
+++ b/sdk-docs/enums/Generated/Types/TechnicalCommitteeMembershipTx/TechnicalCommitteeMembershipTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: TechnicalCommitteeMembershipTx"
 sidebar_label: "TechnicalCommitteeMembershipTx"
 ---
 
-# Enumeration: TechnicalCommitteeMembershipTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).TechnicalCommitteeMembershipTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/TechnicalCommitteeTx/TechnicalCommitteeTx.md
+++ b/sdk-docs/enums/Generated/Types/TechnicalCommitteeTx/TechnicalCommitteeTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: TechnicalCommitteeTx"
 sidebar_label: "TechnicalCommitteeTx"
 ---
 
-# Enumeration: TechnicalCommitteeTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).TechnicalCommitteeTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/TestUtilsTx/TestUtilsTx.md
+++ b/sdk-docs/enums/Generated/Types/TestUtilsTx/TestUtilsTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: TestUtilsTx"
 sidebar_label: "TestUtilsTx"
 ---
 
-# Enumeration: TestUtilsTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).TestUtilsTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/TimestampTx/TimestampTx.md
+++ b/sdk-docs/enums/Generated/Types/TimestampTx/TimestampTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: TimestampTx"
 sidebar_label: "TimestampTx"
 ---
 
-# Enumeration: TimestampTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).TimestampTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/TreasuryTx/TreasuryTx.md
+++ b/sdk-docs/enums/Generated/Types/TreasuryTx/TreasuryTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: TreasuryTx"
 sidebar_label: "TreasuryTx"
 ---
 
-# Enumeration: TreasuryTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).TreasuryTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/UpgradeCommitteeMembershipTx/UpgradeCommitteeMembershipTx.md
+++ b/sdk-docs/enums/Generated/Types/UpgradeCommitteeMembershipTx/UpgradeCommitteeMembershipTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: UpgradeCommitteeMembershipTx"
 sidebar_label: "UpgradeCommitteeMembershipTx"
 ---
 
-# Enumeration: UpgradeCommitteeMembershipTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).UpgradeCommitteeMembershipTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/UpgradeCommitteeTx/UpgradeCommitteeTx.md
+++ b/sdk-docs/enums/Generated/Types/UpgradeCommitteeTx/UpgradeCommitteeTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: UpgradeCommitteeTx"
 sidebar_label: "UpgradeCommitteeTx"
 ---
 
-# Enumeration: UpgradeCommitteeTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).UpgradeCommitteeTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Generated/Types/UtilityTx/UtilityTx.md
+++ b/sdk-docs/enums/Generated/Types/UtilityTx/UtilityTx.md
@@ -4,8 +4,6 @@ title: "Enumeration: UtilityTx"
 sidebar_label: "UtilityTx"
 ---
 
-# Enumeration: UtilityTx
-
 [generated/types](../../../../modules/Generated/Types/Types.md).UtilityTx
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/AssetHoldersOrderBy/AssetHoldersOrderBy.md
+++ b/sdk-docs/enums/Types/AssetHoldersOrderBy/AssetHoldersOrderBy.md
@@ -4,8 +4,6 @@ title: "Enumeration: AssetHoldersOrderBy"
 sidebar_label: "AssetHoldersOrderBy"
 ---
 
-# Enumeration: AssetHoldersOrderBy
-
 [types](../../../modules/Types/Types.md).AssetHoldersOrderBy
 
 Methods to use when ordering `AssetHolder`.

--- a/sdk-docs/enums/Types/AuthTypeEnum/AuthTypeEnum.md
+++ b/sdk-docs/enums/Types/AuthTypeEnum/AuthTypeEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: AuthTypeEnum"
 sidebar_label: "AuthTypeEnum"
 ---
 
-# Enumeration: AuthTypeEnum
-
 [types](../../../modules/Types/Types.md).AuthTypeEnum
 
 \n@enumName AuthTypeEnum

--- a/sdk-docs/enums/Types/AuthorizationStatusEnum/AuthorizationStatusEnum.md
+++ b/sdk-docs/enums/Types/AuthorizationStatusEnum/AuthorizationStatusEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: AuthorizationStatusEnum"
 sidebar_label: "AuthorizationStatusEnum"
 ---
 
-# Enumeration: AuthorizationStatusEnum
-
 [types](../../../modules/Types/Types.md).AuthorizationStatusEnum
 
 \n@enumName AuthorizationStatusEnum

--- a/sdk-docs/enums/Types/AuthorizationType/AuthorizationType.md
+++ b/sdk-docs/enums/Types/AuthorizationType/AuthorizationType.md
@@ -4,8 +4,6 @@ title: "Enumeration: AuthorizationType"
 sidebar_label: "AuthorizationType"
 ---
 
-# Enumeration: AuthorizationType
-
 [types](../../../modules/Types/Types.md).AuthorizationType
 
 Type of Authorization Request

--- a/sdk-docs/enums/Types/CalendarUnit/CalendarUnit.md
+++ b/sdk-docs/enums/Types/CalendarUnit/CalendarUnit.md
@@ -4,8 +4,6 @@ title: "Enumeration: CalendarUnit"
 sidebar_label: "CalendarUnit"
 ---
 
-# Enumeration: CalendarUnit
-
 [types](../../../modules/Types/Types.md).CalendarUnit
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/CallIdEnum/CallIdEnum.md
+++ b/sdk-docs/enums/Types/CallIdEnum/CallIdEnum.md
@@ -4,11 +4,7 @@ title: "Enumeration: CallIdEnum"
 sidebar_label: "CallIdEnum"
 ---
 
-# Enumeration: CallIdEnum
-
 [types](../../../modules/Types/Types.md).CallIdEnum
-
-\n@enumName CallIdEnum
 
 ## Enumeration Members
 

--- a/sdk-docs/enums/Types/ClaimType/ClaimType.md
+++ b/sdk-docs/enums/Types/ClaimType/ClaimType.md
@@ -4,8 +4,6 @@ title: "Enumeration: ClaimType"
 sidebar_label: "ClaimType"
 ---
 
-# Enumeration: ClaimType
-
 [types](../../../modules/Types/Types.md).ClaimType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/ClaimTypeEnum/ClaimTypeEnum.md
+++ b/sdk-docs/enums/Types/ClaimTypeEnum/ClaimTypeEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: ClaimTypeEnum"
 sidebar_label: "ClaimTypeEnum"
 ---
 
-# Enumeration: ClaimTypeEnum
-
 [types](../../../modules/Types/Types.md).ClaimTypeEnum
 
 \n@enumName ClaimTypeEnum

--- a/sdk-docs/enums/Types/ConditionTarget/ConditionTarget.md
+++ b/sdk-docs/enums/Types/ConditionTarget/ConditionTarget.md
@@ -4,8 +4,6 @@ title: "Enumeration: ConditionTarget"
 sidebar_label: "ConditionTarget"
 ---
 
-# Enumeration: ConditionTarget
-
 [types](../../../modules/Types/Types.md).ConditionTarget
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/ConditionType/ConditionType.md
+++ b/sdk-docs/enums/Types/ConditionType/ConditionType.md
@@ -4,8 +4,6 @@ title: "Enumeration: ConditionType"
 sidebar_label: "ConditionType"
 ---
 
-# Enumeration: ConditionType
-
 [types](../../../modules/Types/Types.md).ConditionType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/ErrorCode/ErrorCode.md
+++ b/sdk-docs/enums/Types/ErrorCode/ErrorCode.md
@@ -4,8 +4,6 @@ title: "Enumeration: ErrorCode"
 sidebar_label: "ErrorCode"
 ---
 
-# Enumeration: ErrorCode
-
 [types](../../../modules/Types/Types.md).ErrorCode
 
 Specifies possible types of errors in the SDK

--- a/sdk-docs/enums/Types/EventIdEnum/EventIdEnum.md
+++ b/sdk-docs/enums/Types/EventIdEnum/EventIdEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: EventIdEnum"
 sidebar_label: "EventIdEnum"
 ---
 
-# Enumeration: EventIdEnum
-
 [types](../../../modules/Types/Types.md).EventIdEnum
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/ExtrinsicsOrderBy/ExtrinsicsOrderBy.md
+++ b/sdk-docs/enums/Types/ExtrinsicsOrderBy/ExtrinsicsOrderBy.md
@@ -4,8 +4,6 @@ title: "Enumeration: ExtrinsicsOrderBy"
 sidebar_label: "ExtrinsicsOrderBy"
 ---
 
-# Enumeration: ExtrinsicsOrderBy
-
 [types](../../../modules/Types/Types.md).ExtrinsicsOrderBy
 
 Methods to use when ordering `Extrinsic`.

--- a/sdk-docs/enums/Types/InstructionStatusEnum/InstructionStatusEnum.md
+++ b/sdk-docs/enums/Types/InstructionStatusEnum/InstructionStatusEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: InstructionStatusEnum"
 sidebar_label: "InstructionStatusEnum"
 ---
 
-# Enumeration: InstructionStatusEnum
-
 [types](../../../modules/Types/Types.md).InstructionStatusEnum
 
 \n@enumName InstructionStatusEnum

--- a/sdk-docs/enums/Types/KnownAssetType/KnownAssetType.md
+++ b/sdk-docs/enums/Types/KnownAssetType/KnownAssetType.md
@@ -4,8 +4,6 @@ title: "Enumeration: KnownAssetType"
 sidebar_label: "KnownAssetType"
 ---
 
-# Enumeration: KnownAssetType
-
 [types](../../../modules/Types/Types.md).KnownAssetType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/ModuleIdEnum/ModuleIdEnum.md
+++ b/sdk-docs/enums/Types/ModuleIdEnum/ModuleIdEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: ModuleIdEnum"
 sidebar_label: "ModuleIdEnum"
 ---
 
-# Enumeration: ModuleIdEnum
-
 [types](../../../modules/Types/Types.md).ModuleIdEnum
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/Order/Order.md
+++ b/sdk-docs/enums/Types/Order/Order.md
@@ -4,8 +4,6 @@ title: "Enumeration: Order"
 sidebar_label: "Order"
 ---
 
-# Enumeration: Order
-
 [types](../../../modules/Types/Types.md).Order
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/PayingAccountType/PayingAccountType.md
+++ b/sdk-docs/enums/Types/PayingAccountType/PayingAccountType.md
@@ -4,8 +4,6 @@ title: "Enumeration: PayingAccountType"
 sidebar_label: "PayingAccountType"
 ---
 
-# Enumeration: PayingAccountType
-
 [types](../../../modules/Types/Types.md).PayingAccountType
 
 Type of relationship between a paying account and a beneficiary

--- a/sdk-docs/enums/Types/PermissionGroupType/PermissionGroupType.md
+++ b/sdk-docs/enums/Types/PermissionGroupType/PermissionGroupType.md
@@ -4,8 +4,6 @@ title: "Enumeration: PermissionGroupType"
 sidebar_label: "PermissionGroupType"
 ---
 
-# Enumeration: PermissionGroupType
-
 [types](../../../modules/Types/Types.md).PermissionGroupType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/PermissionType/PermissionType.md
+++ b/sdk-docs/enums/Types/PermissionType/PermissionType.md
@@ -4,8 +4,6 @@ title: "Enumeration: PermissionType"
 sidebar_label: "PermissionType"
 ---
 
-# Enumeration: PermissionType
-
 [types](../../../modules/Types/Types.md).PermissionType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/ProposalStateEnum/ProposalStateEnum.md
+++ b/sdk-docs/enums/Types/ProposalStateEnum/ProposalStateEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: ProposalStateEnum"
 sidebar_label: "ProposalStateEnum"
 ---
 
-# Enumeration: ProposalStateEnum
-
 [types](../../../modules/Types/Types.md).ProposalStateEnum
 
 \n@enumName ProposalStateEnum

--- a/sdk-docs/enums/Types/PublicEnum7A0B4Cc03E/PublicEnum7A0B4Cc03E.md
+++ b/sdk-docs/enums/Types/PublicEnum7A0B4Cc03E/PublicEnum7A0B4Cc03E.md
@@ -4,8 +4,6 @@ title: "Enumeration: PublicEnum7A0B4Cc03E"
 sidebar_label: "PublicEnum7A0B4Cc03E"
 ---
 
-# Enumeration: PublicEnum7A0B4Cc03E
-
 [types](../../../modules/Types/Types.md).PublicEnum7A0B4Cc03E
 
 \n@enumName ModuleIdEnum

--- a/sdk-docs/enums/Types/PublicEnum8F5A39C8Ee/PublicEnum8F5A39C8Ee.md
+++ b/sdk-docs/enums/Types/PublicEnum8F5A39C8Ee/PublicEnum8F5A39C8Ee.md
@@ -4,8 +4,6 @@ title: "Enumeration: PublicEnum8F5A39C8Ee"
 sidebar_label: "PublicEnum8F5A39C8Ee"
 ---
 
-# Enumeration: PublicEnum8F5A39C8Ee
-
 [types](../../../modules/Types/Types.md).PublicEnum8F5A39C8Ee
 
 \n@enumName EventIdEnum

--- a/sdk-docs/enums/Types/RoleType/RoleType.md
+++ b/sdk-docs/enums/Types/RoleType/RoleType.md
@@ -4,8 +4,6 @@ title: "Enumeration: RoleType"
 sidebar_label: "RoleType"
 ---
 
-# Enumeration: RoleType
-
 [types](../../../modules/Types/Types.md).RoleType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/ScopeType/ScopeType.md
+++ b/sdk-docs/enums/Types/ScopeType/ScopeType.md
@@ -4,8 +4,6 @@ title: "Enumeration: ScopeType"
 sidebar_label: "ScopeType"
 ---
 
-# Enumeration: ScopeType
-
 [types](../../../modules/Types/Types.md).ScopeType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/SecurityIdentifierType/SecurityIdentifierType.md
+++ b/sdk-docs/enums/Types/SecurityIdentifierType/SecurityIdentifierType.md
@@ -4,8 +4,6 @@ title: "Enumeration: SecurityIdentifierType"
 sidebar_label: "SecurityIdentifierType"
 ---
 
-# Enumeration: SecurityIdentifierType
-
 [types](../../../modules/Types/Types.md).SecurityIdentifierType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/SettlementDirectionEnum/SettlementDirectionEnum.md
+++ b/sdk-docs/enums/Types/SettlementDirectionEnum/SettlementDirectionEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: SettlementDirectionEnum"
 sidebar_label: "SettlementDirectionEnum"
 ---
 
-# Enumeration: SettlementDirectionEnum
-
 [types](../../../modules/Types/Types.md).SettlementDirectionEnum
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/SettlementResultEnum/SettlementResultEnum.md
+++ b/sdk-docs/enums/Types/SettlementResultEnum/SettlementResultEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: SettlementResultEnum"
 sidebar_label: "SettlementResultEnum"
 ---
 
-# Enumeration: SettlementResultEnum
-
 [types](../../../modules/Types/Types.md).SettlementResultEnum
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/SignerType/SignerType.md
+++ b/sdk-docs/enums/Types/SignerType/SignerType.md
@@ -4,8 +4,6 @@ title: "Enumeration: SignerType"
 sidebar_label: "SignerType"
 ---
 
-# Enumeration: SignerType
-
 [types](../../../modules/Types/Types.md).SignerType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/StatOpTypeEnum/StatOpTypeEnum.md
+++ b/sdk-docs/enums/Types/StatOpTypeEnum/StatOpTypeEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: StatOpTypeEnum"
 sidebar_label: "StatOpTypeEnum"
 ---
 
-# Enumeration: StatOpTypeEnum
-
 [types](../../../modules/Types/Types.md).StatOpTypeEnum
 
 \n@enumName StatOpTypeEnum

--- a/sdk-docs/enums/Types/StatType/StatType.md
+++ b/sdk-docs/enums/Types/StatType/StatType.md
@@ -4,8 +4,6 @@ title: "Enumeration: StatType"
 sidebar_label: "StatType"
 ---
 
-# Enumeration: StatType
-
 [types](../../../modules/Types/Types.md).StatType
 
 Represents the StatType from the `statistics` module.

--- a/sdk-docs/enums/Types/TransactionArgumentType/TransactionArgumentType.md
+++ b/sdk-docs/enums/Types/TransactionArgumentType/TransactionArgumentType.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransactionArgumentType"
 sidebar_label: "TransactionArgumentType"
 ---
 
-# Enumeration: TransactionArgumentType
-
 [types](../../../modules/Types/Types.md).TransactionArgumentType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/TransactionOrderFields/TransactionOrderFields.md
+++ b/sdk-docs/enums/Types/TransactionOrderFields/TransactionOrderFields.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransactionOrderFields"
 sidebar_label: "TransactionOrderFields"
 ---
 
-# Enumeration: TransactionOrderFields
-
 [types](../../../modules/Types/Types.md).TransactionOrderFields
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/TransactionStatus/TransactionStatus.md
+++ b/sdk-docs/enums/Types/TransactionStatus/TransactionStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransactionStatus"
 sidebar_label: "TransactionStatus"
 ---
 
-# Enumeration: TransactionStatus
-
 [types](../../../modules/Types/Types.md).TransactionStatus
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/TransferComplianceTypeEnum/TransferComplianceTypeEnum.md
+++ b/sdk-docs/enums/Types/TransferComplianceTypeEnum/TransferComplianceTypeEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransferComplianceTypeEnum"
 sidebar_label: "TransferComplianceTypeEnum"
 ---
 
-# Enumeration: TransferComplianceTypeEnum
-
 [types](../../../modules/Types/Types.md).TransferComplianceTypeEnum
 
 \n@enumName TransferComplianceTypeEnum

--- a/sdk-docs/enums/Types/TransferError/TransferError.md
+++ b/sdk-docs/enums/Types/TransferError/TransferError.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransferError"
 sidebar_label: "TransferError"
 ---
 
-# Enumeration: TransferError
-
 [types](../../../modules/Types/Types.md).TransferError
 
 Akin to TransferStatus, these are a bit more granular and specific. Every TransferError translates to

--- a/sdk-docs/enums/Types/TransferRestrictionType/TransferRestrictionType.md
+++ b/sdk-docs/enums/Types/TransferRestrictionType/TransferRestrictionType.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransferRestrictionType"
 sidebar_label: "TransferRestrictionType"
 ---
 
-# Enumeration: TransferRestrictionType
-
 [types](../../../modules/Types/Types.md).TransferRestrictionType
 
 ## Enumeration Members

--- a/sdk-docs/enums/Types/TransferRestrictionTypeEnum/TransferRestrictionTypeEnum.md
+++ b/sdk-docs/enums/Types/TransferRestrictionTypeEnum/TransferRestrictionTypeEnum.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransferRestrictionTypeEnum"
 sidebar_label: "TransferRestrictionTypeEnum"
 ---
 
-# Enumeration: TransferRestrictionTypeEnum
-
 [types](../../../modules/Types/Types.md).TransferRestrictionTypeEnum
 
 \n@enumName TransferRestrictionTypeEnum

--- a/sdk-docs/enums/Types/TransferStatus/TransferStatus.md
+++ b/sdk-docs/enums/Types/TransferStatus/TransferStatus.md
@@ -4,8 +4,6 @@ title: "Enumeration: TransferStatus"
 sidebar_label: "TransferStatus"
 ---
 
-# Enumeration: TransferStatus
-
 [types](../../../modules/Types/Types.md).TransferStatus
 
 ERC1400 compliant transfer status

--- a/sdk-docs/enums/Types/TxGroup/TxGroup.md
+++ b/sdk-docs/enums/Types/TxGroup/TxGroup.md
@@ -4,8 +4,6 @@ title: "Enumeration: TxGroup"
 sidebar_label: "TxGroup"
 ---
 
-# Enumeration: TxGroup
-
 [types](../../../modules/Types/Types.md).TxGroup
 
 Transaction Groups (for permissions purposes)

--- a/sdk-docs/interfaces/API/Client/Polymesh/ConnectParams/ConnectParams.md
+++ b/sdk-docs/interfaces/API/Client/Polymesh/ConnectParams/ConnectParams.md
@@ -4,8 +4,6 @@ title: "Interface: ConnectParams"
 sidebar_label: "ConnectParams"
 ---
 
-# Interface: ConnectParams
-
 [api/client/Polymesh](../../../../../modules/API/Client/Polymesh/Polymesh.md).ConnectParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Account/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Account/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Account](../../../../../modules/API/Entities/Account/Account.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Asset/CorporateActions/Types/CorporateActionDefaultConfig/CorporateActionDefaultConfig.md
+++ b/sdk-docs/interfaces/API/Entities/Asset/CorporateActions/Types/CorporateActionDefaultConfig/CorporateActionDefaultConfig.md
@@ -4,8 +4,6 @@ title: "Interface: CorporateActionDefaultConfig"
 sidebar_label: "CorporateActionDefaultConfig"
 ---
 
-# Interface: CorporateActionDefaultConfig
-
 [api/entities/Asset/CorporateActions/types](../../../../../../../modules/API/Entities/Asset/CorporateActions/Types/Types.md).CorporateActionDefaultConfig
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Asset/Types/AgentWithGroup/AgentWithGroup.md
+++ b/sdk-docs/interfaces/API/Entities/Asset/Types/AgentWithGroup/AgentWithGroup.md
@@ -4,8 +4,6 @@ title: "Interface: AgentWithGroup"
 sidebar_label: "AgentWithGroup"
 ---
 
-# Interface: AgentWithGroup
-
 [api/entities/Asset/types](../../../../../../modules/API/Entities/Asset/Types/Types.md).AgentWithGroup
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Asset/Types/AssetDetails/AssetDetails.md
+++ b/sdk-docs/interfaces/API/Entities/Asset/Types/AssetDetails/AssetDetails.md
@@ -4,8 +4,6 @@ title: "Interface: AssetDetails"
 sidebar_label: "AssetDetails"
 ---
 
-# Interface: AssetDetails
-
 [api/entities/Asset/types](../../../../../../modules/API/Entities/Asset/Types/Types.md).AssetDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Asset/Types/IdentityBalance/IdentityBalance.md
+++ b/sdk-docs/interfaces/API/Entities/Asset/Types/IdentityBalance/IdentityBalance.md
@@ -4,8 +4,6 @@ title: "Interface: IdentityBalance"
 sidebar_label: "IdentityBalance"
 ---
 
-# Interface: IdentityBalance
-
 [api/entities/Asset/types](../../../../../../modules/API/Entities/Asset/Types/Types.md).IdentityBalance
 
 Represents the balance of an Asset Holder

--- a/sdk-docs/interfaces/API/Entities/Asset/Types/TransferBreakdown/TransferBreakdown.md
+++ b/sdk-docs/interfaces/API/Entities/Asset/Types/TransferBreakdown/TransferBreakdown.md
@@ -4,8 +4,6 @@ title: "Interface: TransferBreakdown"
 sidebar_label: "TransferBreakdown"
 ---
 
-# Interface: TransferBreakdown
-
 [api/entities/Asset/types](../../../../../../modules/API/Entities/Asset/Types/Types.md).TransferBreakdown
 
 Object containing every reason why a specific Asset transfer would fail

--- a/sdk-docs/interfaces/API/Entities/Asset/Types/TransferRestrictionResult/TransferRestrictionResult.md
+++ b/sdk-docs/interfaces/API/Entities/Asset/Types/TransferRestrictionResult/TransferRestrictionResult.md
@@ -4,8 +4,6 @@ title: "Interface: TransferRestrictionResult"
 sidebar_label: "TransferRestrictionResult"
 ---
 
-# Interface: TransferRestrictionResult
-
 [api/entities/Asset/types](../../../../../../modules/API/Entities/Asset/Types/Types.md).TransferRestrictionResult
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Asset/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Asset/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Asset](../../../../../modules/API/Entities/Asset/Asset.md).UniqueIdentifiers
 
 Properties that uniquely identify an Asset

--- a/sdk-docs/interfaces/API/Entities/AuthorizationRequest/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/AuthorizationRequest/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/AuthorizationRequest](../../../../../modules/API/Entities/AuthorizationRequest/AuthorizationRequest.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/AuthorizationRequest/Params/Params.md
+++ b/sdk-docs/interfaces/API/Entities/AuthorizationRequest/Params/Params.md
@@ -4,8 +4,6 @@ title: "Interface: Params"
 sidebar_label: "Params"
 ---
 
-# Interface: Params
-
 [api/entities/AuthorizationRequest](../../../../../modules/API/Entities/AuthorizationRequest/AuthorizationRequest.md).Params
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/AuthorizationRequest/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/AuthorizationRequest/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/AuthorizationRequest](../../../../../modules/API/Entities/AuthorizationRequest/AuthorizationRequest.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Checkpoint/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/Checkpoint/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/Checkpoint](../../../../../modules/API/Entities/Checkpoint/Checkpoint.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Checkpoint/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Checkpoint/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Checkpoint](../../../../../modules/API/Entities/Checkpoint/Checkpoint.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CheckpointSchedule/CalendarPeriodHumanReadable/CalendarPeriodHumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/CheckpointSchedule/CalendarPeriodHumanReadable/CalendarPeriodHumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: CalendarPeriodHumanReadable"
 sidebar_label: "CalendarPeriodHumanReadable"
 ---
 
-# Interface: CalendarPeriodHumanReadable
-
 [api/entities/CheckpointSchedule](../../../../../modules/API/Entities/CheckpointSchedule/CheckpointSchedule.md).CalendarPeriodHumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CheckpointSchedule/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/CheckpointSchedule/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/CheckpointSchedule](../../../../../modules/API/Entities/CheckpointSchedule/CheckpointSchedule.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CheckpointSchedule/Params/Params.md
+++ b/sdk-docs/interfaces/API/Entities/CheckpointSchedule/Params/Params.md
@@ -4,8 +4,6 @@ title: "Interface: Params"
 sidebar_label: "Params"
 ---
 
-# Interface: Params
-
 [api/entities/CheckpointSchedule](../../../../../modules/API/Entities/CheckpointSchedule/CheckpointSchedule.md).Params
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CheckpointSchedule/Types/ScheduleDetails/ScheduleDetails.md
+++ b/sdk-docs/interfaces/API/Entities/CheckpointSchedule/Types/ScheduleDetails/ScheduleDetails.md
@@ -4,8 +4,6 @@ title: "Interface: ScheduleDetails"
 sidebar_label: "ScheduleDetails"
 ---
 
-# Interface: ScheduleDetails
-
 [api/entities/CheckpointSchedule/types](../../../../../../modules/API/Entities/CheckpointSchedule/Types/Types.md).ScheduleDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CheckpointSchedule/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/CheckpointSchedule/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/CheckpointSchedule](../../../../../modules/API/Entities/CheckpointSchedule/CheckpointSchedule.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CorporateAction/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/CorporateAction/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/CorporateAction](../../../../../modules/API/Entities/CorporateAction/CorporateAction.md).HumanReadable
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Entities/CorporateAction/Params/Params.md
+++ b/sdk-docs/interfaces/API/Entities/CorporateAction/Params/Params.md
@@ -4,8 +4,6 @@ title: "Interface: Params"
 sidebar_label: "Params"
 ---
 
-# Interface: Params
-
 [api/entities/CorporateAction](../../../../../modules/API/Entities/CorporateAction/CorporateAction.md).Params
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CorporateAction/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/CorporateAction/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/CorporateAction](../../../../../modules/API/Entities/CorporateAction/CorporateAction.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CorporateActionBase/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/CorporateActionBase/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/CorporateActionBase](../../../../../modules/API/Entities/CorporateActionBase/CorporateActionBase.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CorporateActionBase/Params/Params.md
+++ b/sdk-docs/interfaces/API/Entities/CorporateActionBase/Params/Params.md
@@ -4,8 +4,6 @@ title: "Interface: Params"
 sidebar_label: "Params"
 ---
 
-# Interface: Params
-
 [api/entities/CorporateActionBase](../../../../../modules/API/Entities/CorporateActionBase/CorporateActionBase.md).Params
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CorporateActionBase/Types/CorporateActionTargets/CorporateActionTargets.md
+++ b/sdk-docs/interfaces/API/Entities/CorporateActionBase/Types/CorporateActionTargets/CorporateActionTargets.md
@@ -4,8 +4,6 @@ title: "Interface: CorporateActionTargets"
 sidebar_label: "CorporateActionTargets"
 ---
 
-# Interface: CorporateActionTargets
-
 [api/entities/CorporateActionBase/types](../../../../../../modules/API/Entities/CorporateActionBase/Types/Types.md).CorporateActionTargets
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CorporateActionBase/Types/TaxWithholding/TaxWithholding.md
+++ b/sdk-docs/interfaces/API/Entities/CorporateActionBase/Types/TaxWithholding/TaxWithholding.md
@@ -4,8 +4,6 @@ title: "Interface: TaxWithholding"
 sidebar_label: "TaxWithholding"
 ---
 
-# Interface: TaxWithholding
-
 [api/entities/CorporateActionBase/types](../../../../../../modules/API/Entities/CorporateActionBase/Types/Types.md).TaxWithholding
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CorporateActionBase/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/CorporateActionBase/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/CorporateActionBase](../../../../../modules/API/Entities/CorporateActionBase/CorporateActionBase.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CustomPermissionGroup/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/CustomPermissionGroup/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/CustomPermissionGroup](../../../../../modules/API/Entities/CustomPermissionGroup/CustomPermissionGroup.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/CustomPermissionGroup/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/CustomPermissionGroup/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/CustomPermissionGroup](../../../../../modules/API/Entities/CustomPermissionGroup/CustomPermissionGroup.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/DefaultPortfolio/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/DefaultPortfolio/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/DefaultPortfolio](../../../../../modules/API/Entities/DefaultPortfolio/DefaultPortfolio.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/DefaultTrustedClaimIssuer/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/DefaultTrustedClaimIssuer/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/DefaultTrustedClaimIssuer](../../../../../modules/API/Entities/DefaultTrustedClaimIssuer/DefaultTrustedClaimIssuer.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/DividendDistribution/DividendDistributionParams/DividendDistributionParams.md
+++ b/sdk-docs/interfaces/API/Entities/DividendDistribution/DividendDistributionParams/DividendDistributionParams.md
@@ -4,8 +4,6 @@ title: "Interface: DividendDistributionParams"
 sidebar_label: "DividendDistributionParams"
 ---
 
-# Interface: DividendDistributionParams
-
 [api/entities/DividendDistribution](../../../../../modules/API/Entities/DividendDistribution/DividendDistribution.md).DividendDistributionParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/DividendDistribution/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/DividendDistribution/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/DividendDistribution](../../../../../modules/API/Entities/DividendDistribution/DividendDistribution.md).HumanReadable
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Entities/DividendDistribution/Types/DistributionParticipant/DistributionParticipant.md
+++ b/sdk-docs/interfaces/API/Entities/DividendDistribution/Types/DistributionParticipant/DistributionParticipant.md
@@ -4,8 +4,6 @@ title: "Interface: DistributionParticipant"
 sidebar_label: "DistributionParticipant"
 ---
 
-# Interface: DistributionParticipant
-
 [api/entities/DividendDistribution/types](../../../../../../modules/API/Entities/DividendDistribution/Types/Types.md).DistributionParticipant
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/DividendDistribution/Types/DividendDistributionDetails/DividendDistributionDetails.md
+++ b/sdk-docs/interfaces/API/Entities/DividendDistribution/Types/DividendDistributionDetails/DividendDistributionDetails.md
@@ -4,8 +4,6 @@ title: "Interface: DividendDistributionDetails"
 sidebar_label: "DividendDistributionDetails"
 ---
 
-# Interface: DividendDistributionDetails
-
 [api/entities/DividendDistribution/types](../../../../../../modules/API/Entities/DividendDistribution/Types/Types.md).DividendDistributionDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Identity/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Identity/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Identity](../../../../../modules/API/Entities/Identity/Identity.md).UniqueIdentifiers
 
 Properties that uniquely identify an Identity

--- a/sdk-docs/interfaces/API/Entities/Instruction/Types/InstructionAffirmation/InstructionAffirmation.md
+++ b/sdk-docs/interfaces/API/Entities/Instruction/Types/InstructionAffirmation/InstructionAffirmation.md
@@ -4,8 +4,6 @@ title: "Interface: InstructionAffirmation"
 sidebar_label: "InstructionAffirmation"
 ---
 
-# Interface: InstructionAffirmation
-
 [api/entities/Instruction/types](../../../../../../modules/API/Entities/Instruction/Types/Types.md).InstructionAffirmation
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Instruction/Types/Leg/Leg.md
+++ b/sdk-docs/interfaces/API/Entities/Instruction/Types/Leg/Leg.md
@@ -4,8 +4,6 @@ title: "Interface: Leg"
 sidebar_label: "Leg"
 ---
 
-# Interface: Leg
-
 [api/entities/Instruction/types](../../../../../../modules/API/Entities/Instruction/Types/Types.md).Leg
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Entities/Instruction/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Instruction/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Instruction](../../../../../modules/API/Entities/Instruction/Instruction.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/KnownPermissionGroup/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/KnownPermissionGroup/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/KnownPermissionGroup](../../../../../modules/API/Entities/KnownPermissionGroup/KnownPermissionGroup.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/KnownPermissionGroup/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/KnownPermissionGroup/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/KnownPermissionGroup](../../../../../modules/API/Entities/KnownPermissionGroup/KnownPermissionGroup.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/MetadataEntry/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/MetadataEntry/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/MetadataEntry](../../../../../modules/API/Entities/MetadataEntry/MetadataEntry.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/MetadataEntry/Types/MetadataDetails/MetadataDetails.md
+++ b/sdk-docs/interfaces/API/Entities/MetadataEntry/Types/MetadataDetails/MetadataDetails.md
@@ -4,8 +4,6 @@ title: "Interface: MetadataDetails"
 sidebar_label: "MetadataDetails"
 ---
 
-# Interface: MetadataDetails
-
 [api/entities/MetadataEntry/types](../../../../../../modules/API/Entities/MetadataEntry/Types/Types.md).MetadataDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/MetadataEntry/Types/MetadataSpec/MetadataSpec.md
+++ b/sdk-docs/interfaces/API/Entities/MetadataEntry/Types/MetadataSpec/MetadataSpec.md
@@ -4,8 +4,6 @@ title: "Interface: MetadataSpec"
 sidebar_label: "MetadataSpec"
 ---
 
-# Interface: MetadataSpec
-
 [api/entities/MetadataEntry/types](../../../../../../modules/API/Entities/MetadataEntry/Types/Types.md).MetadataSpec
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/MetadataEntry/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/MetadataEntry/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/MetadataEntry](../../../../../modules/API/Entities/MetadataEntry/MetadataEntry.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/MultiSig/Types/MultiSigDetails/MultiSigDetails.md
+++ b/sdk-docs/interfaces/API/Entities/MultiSig/Types/MultiSigDetails/MultiSigDetails.md
@@ -4,8 +4,6 @@ title: "Interface: MultiSigDetails"
 sidebar_label: "MultiSigDetails"
 ---
 
-# Interface: MultiSigDetails
-
 [api/entities/MultiSig/types](../../../../../../modules/API/Entities/MultiSig/Types/Types.md).MultiSigDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/MultiSigProposal/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/MultiSigProposal/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/MultiSigProposal](../../../../../modules/API/Entities/MultiSigProposal/MultiSigProposal.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/MultiSigProposal/Types/MultiSigProposalDetails/MultiSigProposalDetails.md
+++ b/sdk-docs/interfaces/API/Entities/MultiSigProposal/Types/MultiSigProposalDetails/MultiSigProposalDetails.md
@@ -4,8 +4,6 @@ title: "Interface: MultiSigProposalDetails"
 sidebar_label: "MultiSigProposalDetails"
 ---
 
-# Interface: MultiSigProposalDetails
-
 [api/entities/MultiSigProposal/types](../../../../../../modules/API/Entities/MultiSigProposal/Types/Types.md).MultiSigProposalDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/NumberedPortfolio/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/NumberedPortfolio/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/NumberedPortfolio](../../../../../modules/API/Entities/NumberedPortfolio/NumberedPortfolio.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Offering/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/Offering/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/Offering](../../../../../modules/API/Entities/Offering/Offering.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Offering/Types/Investment/Investment.md
+++ b/sdk-docs/interfaces/API/Entities/Offering/Types/Investment/Investment.md
@@ -4,8 +4,6 @@ title: "Interface: Investment"
 sidebar_label: "Investment"
 ---
 
-# Interface: Investment
-
 [api/entities/Offering/types](../../../../../../modules/API/Entities/Offering/Types/Types.md).Investment
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Offering/Types/OfferingDetails/OfferingDetails.md
+++ b/sdk-docs/interfaces/API/Entities/Offering/Types/OfferingDetails/OfferingDetails.md
@@ -4,8 +4,6 @@ title: "Interface: OfferingDetails"
 sidebar_label: "OfferingDetails"
 ---
 
-# Interface: OfferingDetails
-
 [api/entities/Offering/types](../../../../../../modules/API/Entities/Offering/Types/Types.md).OfferingDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Offering/Types/OfferingStatus/OfferingStatus.md
+++ b/sdk-docs/interfaces/API/Entities/Offering/Types/OfferingStatus/OfferingStatus.md
@@ -4,8 +4,6 @@ title: "Interface: OfferingStatus"
 sidebar_label: "OfferingStatus"
 ---
 
-# Interface: OfferingStatus
-
 [api/entities/Offering/types](../../../../../../modules/API/Entities/Offering/Types/Types.md).OfferingStatus
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Offering/Types/OfferingTier/OfferingTier.md
+++ b/sdk-docs/interfaces/API/Entities/Offering/Types/OfferingTier/OfferingTier.md
@@ -4,8 +4,6 @@ title: "Interface: OfferingTier"
 sidebar_label: "OfferingTier"
 ---
 
-# Interface: OfferingTier
-
 [api/entities/Offering/types](../../../../../../modules/API/Entities/Offering/Types/Types.md).OfferingTier
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Entities/Offering/Types/Tier/Tier.md
+++ b/sdk-docs/interfaces/API/Entities/Offering/Types/Tier/Tier.md
@@ -4,8 +4,6 @@ title: "Interface: Tier"
 sidebar_label: "Tier"
 ---
 
-# Interface: Tier
-
 [api/entities/Offering/types](../../../../../../modules/API/Entities/Offering/Types/Types.md).Tier
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Entities/Offering/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Offering/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Offering](../../../../../modules/API/Entities/Offering/Offering.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/PermissionGroup/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/PermissionGroup/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/PermissionGroup](../../../../../modules/API/Entities/PermissionGroup/PermissionGroup.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Portfolio/HumanReadable/HumanReadable.md
+++ b/sdk-docs/interfaces/API/Entities/Portfolio/HumanReadable/HumanReadable.md
@@ -4,8 +4,6 @@ title: "Interface: HumanReadable"
 sidebar_label: "HumanReadable"
 ---
 
-# Interface: HumanReadable
-
 [api/entities/Portfolio](../../../../../modules/API/Entities/Portfolio/Portfolio.md).HumanReadable
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Portfolio/Types/HistoricSettlement/HistoricSettlement.md
+++ b/sdk-docs/interfaces/API/Entities/Portfolio/Types/HistoricSettlement/HistoricSettlement.md
@@ -4,8 +4,6 @@ title: "Interface: HistoricSettlement"
 sidebar_label: "HistoricSettlement"
 ---
 
-# Interface: HistoricSettlement
-
 [api/entities/Portfolio/types](../../../../../../modules/API/Entities/Portfolio/Types/Types.md).HistoricSettlement
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Portfolio/Types/PortfolioBalance/PortfolioBalance.md
+++ b/sdk-docs/interfaces/API/Entities/Portfolio/Types/PortfolioBalance/PortfolioBalance.md
@@ -4,8 +4,6 @@ title: "Interface: PortfolioBalance"
 sidebar_label: "PortfolioBalance"
 ---
 
-# Interface: PortfolioBalance
-
 [api/entities/Portfolio/types](../../../../../../modules/API/Entities/Portfolio/Types/Types.md).PortfolioBalance
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Entities/Portfolio/Types/SettlementLeg/SettlementLeg.md
+++ b/sdk-docs/interfaces/API/Entities/Portfolio/Types/SettlementLeg/SettlementLeg.md
@@ -4,8 +4,6 @@ title: "Interface: SettlementLeg"
 sidebar_label: "SettlementLeg"
 ---
 
-# Interface: SettlementLeg
-
 [api/entities/Portfolio/types](../../../../../../modules/API/Entities/Portfolio/Types/Types.md).SettlementLeg
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Entities/Portfolio/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Portfolio/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Portfolio](../../../../../modules/API/Entities/Portfolio/Portfolio.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Subsidy/Types/SubsidyData/SubsidyData.md
+++ b/sdk-docs/interfaces/API/Entities/Subsidy/Types/SubsidyData/SubsidyData.md
@@ -4,8 +4,6 @@ title: "Interface: SubsidyData"
 sidebar_label: "SubsidyData"
 ---
 
-# Interface: SubsidyData
-
 [api/entities/Subsidy/types](../../../../../../modules/API/Entities/Subsidy/Types/Types.md).SubsidyData
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Subsidy/Types/SubsidyWithAllowance/SubsidyWithAllowance.md
+++ b/sdk-docs/interfaces/API/Entities/Subsidy/Types/SubsidyWithAllowance/SubsidyWithAllowance.md
@@ -4,8 +4,6 @@ title: "Interface: SubsidyWithAllowance"
 sidebar_label: "SubsidyWithAllowance"
 ---
 
-# Interface: SubsidyWithAllowance
-
 [api/entities/Subsidy/types](../../../../../../modules/API/Entities/Subsidy/Types/Types.md).SubsidyWithAllowance
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Subsidy/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Subsidy/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Subsidy](../../../../../modules/API/Entities/Subsidy/Subsidy.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/TickerReservation/Types/TickerReservationDetails/TickerReservationDetails.md
+++ b/sdk-docs/interfaces/API/Entities/TickerReservation/Types/TickerReservationDetails/TickerReservationDetails.md
@@ -4,8 +4,6 @@ title: "Interface: TickerReservationDetails"
 sidebar_label: "TickerReservationDetails"
 ---
 
-# Interface: TickerReservationDetails
-
 [api/entities/TickerReservation/types](../../../../../../modules/API/Entities/TickerReservation/Types/Types.md).TickerReservationDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/TickerReservation/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/TickerReservation/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/TickerReservation](../../../../../modules/API/Entities/TickerReservation/TickerReservation.md).UniqueIdentifiers
 
 Properties that uniquely identify a TickerReservation

--- a/sdk-docs/interfaces/API/Entities/Venue/Types/VenueDetails/VenueDetails.md
+++ b/sdk-docs/interfaces/API/Entities/Venue/Types/VenueDetails/VenueDetails.md
@@ -4,8 +4,6 @@ title: "Interface: VenueDetails"
 sidebar_label: "VenueDetails"
 ---
 
-# Interface: VenueDetails
-
 [api/entities/Venue/types](../../../../../../modules/API/Entities/Venue/Types/Types.md).VenueDetails
 
 ## Properties

--- a/sdk-docs/interfaces/API/Entities/Venue/UniqueIdentifiers/UniqueIdentifiers.md
+++ b/sdk-docs/interfaces/API/Entities/Venue/UniqueIdentifiers/UniqueIdentifiers.md
@@ -4,8 +4,6 @@ title: "Interface: UniqueIdentifiers"
 sidebar_label: "UniqueIdentifiers"
 ---
 
-# Interface: UniqueIdentifiers
-
 [api/entities/Venue](../../../../../modules/API/Entities/Venue/Venue.md).UniqueIdentifiers
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/AddAssetRequirementParams/AddAssetRequirementParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/AddAssetRequirementParams/AddAssetRequirementParams.md
@@ -4,8 +4,6 @@ title: "Interface: AddAssetRequirementParams"
 sidebar_label: "AddAssetRequirementParams"
 ---
 
-# Interface: AddAssetRequirementParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AddAssetRequirementParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/AddClaimsParams/AddClaimsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/AddClaimsParams/AddClaimsParams.md
@@ -4,8 +4,6 @@ title: "Interface: AddClaimsParams"
 sidebar_label: "AddClaimsParams"
 ---
 
-# Interface: AddClaimsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AddClaimsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/AddInstructionParams/AddInstructionParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/AddInstructionParams/AddInstructionParams.md
@@ -4,8 +4,6 @@ title: "Interface: AddInstructionParams"
 sidebar_label: "AddInstructionParams"
 ---
 
-# Interface: AddInstructionParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AddInstructionParams
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/AddInstructionWithVenueIdParams/AddInstructionWithVenueIdParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/AddInstructionWithVenueIdParams/AddInstructionWithVenueIdParams.md
@@ -4,8 +4,6 @@ title: "Interface: AddInstructionWithVenueIdParams"
 sidebar_label: "AddInstructionWithVenueIdParams"
 ---
 
-# Interface: AddInstructionWithVenueIdParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AddInstructionWithVenueIdParams
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/AddInstructionsParams/AddInstructionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/AddInstructionsParams/AddInstructionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: AddInstructionsParams"
 sidebar_label: "AddInstructionsParams"
 ---
 
-# Interface: AddInstructionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AddInstructionsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/AddInvestorUniquenessClaimParams/AddInvestorUniquenessClaimParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/AddInvestorUniquenessClaimParams/AddInvestorUniquenessClaimParams.md
@@ -4,8 +4,6 @@ title: "Interface: AddInvestorUniquenessClaimParams"
 sidebar_label: "AddInvestorUniquenessClaimParams"
 ---
 
-# Interface: AddInvestorUniquenessClaimParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AddInvestorUniquenessClaimParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/AffirmInstructionParams/AffirmInstructionParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/AffirmInstructionParams/AffirmInstructionParams.md
@@ -4,8 +4,6 @@ title: "Interface: AffirmInstructionParams"
 sidebar_label: "AffirmInstructionParams"
 ---
 
-# Interface: AffirmInstructionParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AffirmInstructionParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/AssetBase/AssetBase.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/AssetBase/AssetBase.md
@@ -4,8 +4,6 @@ title: "Interface: AssetBase"
 sidebar_label: "AssetBase"
 ---
 
-# Interface: AssetBase
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).AssetBase
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/ClaimClassicTickerParams/ClaimClassicTickerParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ClaimClassicTickerParams/ClaimClassicTickerParams.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimClassicTickerParams"
 sidebar_label: "ClaimClassicTickerParams"
 ---
 
-# Interface: ClaimClassicTickerParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ClaimClassicTickerParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ClaimCountTransferRestrictionInput/ClaimCountTransferRestrictionInput.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ClaimCountTransferRestrictionInput/ClaimCountTransferRestrictionInput.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimCountTransferRestrictionInput"
 sidebar_label: "ClaimCountTransferRestrictionInput"
 ---
 
-# Interface: ClaimCountTransferRestrictionInput
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ClaimCountTransferRestrictionInput
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/ClaimPercentageTransferRestrictionInput/ClaimPercentageTransferRestrictionInput.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ClaimPercentageTransferRestrictionInput/ClaimPercentageTransferRestrictionInput.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimPercentageTransferRestrictionInput"
 sidebar_label: "ClaimPercentageTransferRestrictionInput"
 ---
 
-# Interface: ClaimPercentageTransferRestrictionInput
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ClaimPercentageTransferRestrictionInput
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/ConfigureDividendDistributionParams/ConfigureDividendDistributionParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ConfigureDividendDistributionParams/ConfigureDividendDistributionParams.md
@@ -4,8 +4,6 @@ title: "Interface: ConfigureDividendDistributionParams"
 sidebar_label: "ConfigureDividendDistributionParams"
 ---
 
-# Interface: ConfigureDividendDistributionParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ConfigureDividendDistributionParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ControllerTransferParams/ControllerTransferParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ControllerTransferParams/ControllerTransferParams.md
@@ -4,8 +4,6 @@ title: "Interface: ControllerTransferParams"
 sidebar_label: "ControllerTransferParams"
 ---
 
-# Interface: ControllerTransferParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ControllerTransferParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/CountTransferRestrictionInput/CountTransferRestrictionInput.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/CountTransferRestrictionInput/CountTransferRestrictionInput.md
@@ -4,8 +4,6 @@ title: "Interface: CountTransferRestrictionInput"
 sidebar_label: "CountTransferRestrictionInput"
 ---
 
-# Interface: CountTransferRestrictionInput
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).CountTransferRestrictionInput
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/CreateAssetParams/CreateAssetParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/CreateAssetParams/CreateAssetParams.md
@@ -4,8 +4,6 @@ title: "Interface: CreateAssetParams"
 sidebar_label: "CreateAssetParams"
 ---
 
-# Interface: CreateAssetParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).CreateAssetParams
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/CreateAssetWithTickerParams/CreateAssetWithTickerParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/CreateAssetWithTickerParams/CreateAssetWithTickerParams.md
@@ -4,8 +4,6 @@ title: "Interface: CreateAssetWithTickerParams"
 sidebar_label: "CreateAssetWithTickerParams"
 ---
 
-# Interface: CreateAssetWithTickerParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).CreateAssetWithTickerParams
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/CreateCheckpointScheduleParams/CreateCheckpointScheduleParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/CreateCheckpointScheduleParams/CreateCheckpointScheduleParams.md
@@ -4,8 +4,6 @@ title: "Interface: CreateCheckpointScheduleParams"
 sidebar_label: "CreateCheckpointScheduleParams"
 ---
 
-# Interface: CreateCheckpointScheduleParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).CreateCheckpointScheduleParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/CreateGroupParams/CreateGroupParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/CreateGroupParams/CreateGroupParams.md
@@ -4,8 +4,6 @@ title: "Interface: CreateGroupParams"
 sidebar_label: "CreateGroupParams"
 ---
 
-# Interface: CreateGroupParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).CreateGroupParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/CreateMultiSigParams/CreateMultiSigParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/CreateMultiSigParams/CreateMultiSigParams.md
@@ -4,8 +4,6 @@ title: "Interface: CreateMultiSigParams"
 sidebar_label: "CreateMultiSigParams"
 ---
 
-# Interface: CreateMultiSigParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).CreateMultiSigParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/CreateTransactionBatchParams/CreateTransactionBatchParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/CreateTransactionBatchParams/CreateTransactionBatchParams.md
@@ -4,8 +4,6 @@ title: "Interface: CreateTransactionBatchParams<ReturnValues>"
 sidebar_label: "CreateTransactionBatchParams"
 ---
 
-# Interface: CreateTransactionBatchParams<ReturnValues\>
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).CreateTransactionBatchParams
 
 ## Type parameters

--- a/sdk-docs/interfaces/API/Procedures/Types/CreateVenueParams/CreateVenueParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/CreateVenueParams/CreateVenueParams.md
@@ -4,8 +4,6 @@ title: "Interface: CreateVenueParams"
 sidebar_label: "CreateVenueParams"
 ---
 
-# Interface: CreateVenueParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).CreateVenueParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/DecreaseAllowanceParams/DecreaseAllowanceParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/DecreaseAllowanceParams/DecreaseAllowanceParams.md
@@ -4,8 +4,6 @@ title: "Interface: DecreaseAllowanceParams"
 sidebar_label: "DecreaseAllowanceParams"
 ---
 
-# Interface: DecreaseAllowanceParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).DecreaseAllowanceParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/EditClaimsParams/EditClaimsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/EditClaimsParams/EditClaimsParams.md
@@ -4,8 +4,6 @@ title: "Interface: EditClaimsParams"
 sidebar_label: "EditClaimsParams"
 ---
 
-# Interface: EditClaimsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).EditClaimsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/IncreaseAllowanceParams/IncreaseAllowanceParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/IncreaseAllowanceParams/IncreaseAllowanceParams.md
@@ -4,8 +4,6 @@ title: "Interface: IncreaseAllowanceParams"
 sidebar_label: "IncreaseAllowanceParams"
 ---
 
-# Interface: IncreaseAllowanceParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).IncreaseAllowanceParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/InvestInOfferingParams/InvestInOfferingParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/InvestInOfferingParams/InvestInOfferingParams.md
@@ -4,8 +4,6 @@ title: "Interface: InvestInOfferingParams"
 sidebar_label: "InvestInOfferingParams"
 ---
 
-# Interface: InvestInOfferingParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).InvestInOfferingParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/InviteAccountParams/InviteAccountParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/InviteAccountParams/InviteAccountParams.md
@@ -4,8 +4,6 @@ title: "Interface: InviteAccountParams"
 sidebar_label: "InviteAccountParams"
 ---
 
-# Interface: InviteAccountParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).InviteAccountParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/InviteExternalAgentParams/InviteExternalAgentParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/InviteExternalAgentParams/InviteExternalAgentParams.md
@@ -4,8 +4,6 @@ title: "Interface: InviteExternalAgentParams"
 sidebar_label: "InviteExternalAgentParams"
 ---
 
-# Interface: InviteExternalAgentParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).InviteExternalAgentParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/LaunchOfferingParams/LaunchOfferingParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/LaunchOfferingParams/LaunchOfferingParams.md
@@ -4,8 +4,6 @@ title: "Interface: LaunchOfferingParams"
 sidebar_label: "LaunchOfferingParams"
 ---
 
-# Interface: LaunchOfferingParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).LaunchOfferingParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/LinkCaDocsParams/LinkCaDocsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/LinkCaDocsParams/LinkCaDocsParams.md
@@ -4,8 +4,6 @@ title: "Interface: LinkCaDocsParams"
 sidebar_label: "LinkCaDocsParams"
 ---
 
-# Interface: LinkCaDocsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).LinkCaDocsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ModifyAssetTrustedClaimIssuersAddSetParams/ModifyAssetTrustedClaimIssuersAddSetParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ModifyAssetTrustedClaimIssuersAddSetParams/ModifyAssetTrustedClaimIssuersAddSetParams.md
@@ -4,8 +4,6 @@ title: "Interface: ModifyAssetTrustedClaimIssuersAddSetParams"
 sidebar_label: "ModifyAssetTrustedClaimIssuersAddSetParams"
 ---
 
-# Interface: ModifyAssetTrustedClaimIssuersAddSetParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ModifyAssetTrustedClaimIssuersAddSetParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ModifyAssetTrustedClaimIssuersRemoveParams/ModifyAssetTrustedClaimIssuersRemoveParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ModifyAssetTrustedClaimIssuersRemoveParams/ModifyAssetTrustedClaimIssuersRemoveParams.md
@@ -4,8 +4,6 @@ title: "Interface: ModifyAssetTrustedClaimIssuersRemoveParams"
 sidebar_label: "ModifyAssetTrustedClaimIssuersRemoveParams"
 ---
 
-# Interface: ModifyAssetTrustedClaimIssuersRemoveParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ModifyAssetTrustedClaimIssuersRemoveParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ModifyCaCheckpointParams/ModifyCaCheckpointParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ModifyCaCheckpointParams/ModifyCaCheckpointParams.md
@@ -4,8 +4,6 @@ title: "Interface: ModifyCaCheckpointParams"
 sidebar_label: "ModifyCaCheckpointParams"
 ---
 
-# Interface: ModifyCaCheckpointParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ModifyCaCheckpointParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ModifyCorporateActionsAgentParams/ModifyCorporateActionsAgentParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ModifyCorporateActionsAgentParams/ModifyCorporateActionsAgentParams.md
@@ -4,8 +4,6 @@ title: "Interface: ModifyCorporateActionsAgentParams"
 sidebar_label: "ModifyCorporateActionsAgentParams"
 ---
 
-# Interface: ModifyCorporateActionsAgentParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ModifyCorporateActionsAgentParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ModifyInstructionAffirmationParams/ModifyInstructionAffirmationParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ModifyInstructionAffirmationParams/ModifyInstructionAffirmationParams.md
@@ -4,8 +4,6 @@ title: "Interface: ModifyInstructionAffirmationParams"
 sidebar_label: "ModifyInstructionAffirmationParams"
 ---
 
-# Interface: ModifyInstructionAffirmationParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ModifyInstructionAffirmationParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ModifyMultiSigParams/ModifyMultiSigParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ModifyMultiSigParams/ModifyMultiSigParams.md
@@ -4,8 +4,6 @@ title: "Interface: ModifyMultiSigParams"
 sidebar_label: "ModifyMultiSigParams"
 ---
 
-# Interface: ModifyMultiSigParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ModifyMultiSigParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ModifyPrimaryIssuanceAgentParams/ModifyPrimaryIssuanceAgentParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ModifyPrimaryIssuanceAgentParams/ModifyPrimaryIssuanceAgentParams.md
@@ -4,8 +4,6 @@ title: "Interface: ModifyPrimaryIssuanceAgentParams"
 sidebar_label: "ModifyPrimaryIssuanceAgentParams"
 ---
 
-# Interface: ModifyPrimaryIssuanceAgentParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ModifyPrimaryIssuanceAgentParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ModifySignerPermissionsParams/ModifySignerPermissionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ModifySignerPermissionsParams/ModifySignerPermissionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: ModifySignerPermissionsParams"
 sidebar_label: "ModifySignerPermissionsParams"
 ---
 
-# Interface: ModifySignerPermissionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ModifySignerPermissionsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/MoveFundsParams/MoveFundsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/MoveFundsParams/MoveFundsParams.md
@@ -4,8 +4,6 @@ title: "Interface: MoveFundsParams"
 sidebar_label: "MoveFundsParams"
 ---
 
-# Interface: MoveFundsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).MoveFundsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/PayDividendsParams/PayDividendsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/PayDividendsParams/PayDividendsParams.md
@@ -4,8 +4,6 @@ title: "Interface: PayDividendsParams"
 sidebar_label: "PayDividendsParams"
 ---
 
-# Interface: PayDividendsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).PayDividendsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/PercentageTransferRestrictionInput/PercentageTransferRestrictionInput.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/PercentageTransferRestrictionInput/PercentageTransferRestrictionInput.md
@@ -4,8 +4,6 @@ title: "Interface: PercentageTransferRestrictionInput"
 sidebar_label: "PercentageTransferRestrictionInput"
 ---
 
-# Interface: PercentageTransferRestrictionInput
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).PercentageTransferRestrictionInput
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/RedeemTokensParams/RedeemTokensParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RedeemTokensParams/RedeemTokensParams.md
@@ -4,8 +4,6 @@ title: "Interface: RedeemTokensParams"
 sidebar_label: "RedeemTokensParams"
 ---
 
-# Interface: RedeemTokensParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RedeemTokensParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/RegisterIdentityParams/RegisterIdentityParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RegisterIdentityParams/RegisterIdentityParams.md
@@ -4,8 +4,6 @@ title: "Interface: RegisterIdentityParams"
 sidebar_label: "RegisterIdentityParams"
 ---
 
-# Interface: RegisterIdentityParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RegisterIdentityParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/RemoveAssetRequirementParams/RemoveAssetRequirementParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RemoveAssetRequirementParams/RemoveAssetRequirementParams.md
@@ -4,8 +4,6 @@ title: "Interface: RemoveAssetRequirementParams"
 sidebar_label: "RemoveAssetRequirementParams"
 ---
 
-# Interface: RemoveAssetRequirementParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RemoveAssetRequirementParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/RemoveCheckpointScheduleParams/RemoveCheckpointScheduleParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RemoveCheckpointScheduleParams/RemoveCheckpointScheduleParams.md
@@ -4,8 +4,6 @@ title: "Interface: RemoveCheckpointScheduleParams"
 sidebar_label: "RemoveCheckpointScheduleParams"
 ---
 
-# Interface: RemoveCheckpointScheduleParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RemoveCheckpointScheduleParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/RemoveCorporateActionParams/RemoveCorporateActionParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RemoveCorporateActionParams/RemoveCorporateActionParams.md
@@ -4,8 +4,6 @@ title: "Interface: RemoveCorporateActionParams"
 sidebar_label: "RemoveCorporateActionParams"
 ---
 
-# Interface: RemoveCorporateActionParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RemoveCorporateActionParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/RemoveExternalAgentParams/RemoveExternalAgentParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RemoveExternalAgentParams/RemoveExternalAgentParams.md
@@ -4,8 +4,6 @@ title: "Interface: RemoveExternalAgentParams"
 sidebar_label: "RemoveExternalAgentParams"
 ---
 
-# Interface: RemoveExternalAgentParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RemoveExternalAgentParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/RemoveSecondaryAccountsParams/RemoveSecondaryAccountsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RemoveSecondaryAccountsParams/RemoveSecondaryAccountsParams.md
@@ -4,8 +4,6 @@ title: "Interface: RemoveSecondaryAccountsParams"
 sidebar_label: "RemoveSecondaryAccountsParams"
 ---
 
-# Interface: RemoveSecondaryAccountsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RemoveSecondaryAccountsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/RenamePortfolioParams/RenamePortfolioParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RenamePortfolioParams/RenamePortfolioParams.md
@@ -4,8 +4,6 @@ title: "Interface: RenamePortfolioParams"
 sidebar_label: "RenamePortfolioParams"
 ---
 
-# Interface: RenamePortfolioParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RenamePortfolioParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ReserveTickerParams/ReserveTickerParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ReserveTickerParams/ReserveTickerParams.md
@@ -4,8 +4,6 @@ title: "Interface: ReserveTickerParams"
 sidebar_label: "ReserveTickerParams"
 ---
 
-# Interface: ReserveTickerParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ReserveTickerParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/RevokeClaimsParams/RevokeClaimsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/RevokeClaimsParams/RevokeClaimsParams.md
@@ -4,8 +4,6 @@ title: "Interface: RevokeClaimsParams"
 sidebar_label: "RevokeClaimsParams"
 ---
 
-# Interface: RevokeClaimsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).RevokeClaimsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/ScopeClaimProof/ScopeClaimProof.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/ScopeClaimProof/ScopeClaimProof.md
@@ -4,8 +4,6 @@ title: "Interface: ScopeClaimProof"
 sidebar_label: "ScopeClaimProof"
 ---
 
-# Interface: ScopeClaimProof
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).ScopeClaimProof
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetAllowanceParams/SetAllowanceParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetAllowanceParams/SetAllowanceParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetAllowanceParams"
 sidebar_label: "SetAllowanceParams"
 ---
 
-# Interface: SetAllowanceParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetAllowanceParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetAssetDocumentsParams/SetAssetDocumentsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetAssetDocumentsParams/SetAssetDocumentsParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetAssetDocumentsParams"
 sidebar_label: "SetAssetDocumentsParams"
 ---
 
-# Interface: SetAssetDocumentsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetAssetDocumentsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetAssetRequirementsParams/SetAssetRequirementsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetAssetRequirementsParams/SetAssetRequirementsParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetAssetRequirementsParams"
 sidebar_label: "SetAssetRequirementsParams"
 ---
 
-# Interface: SetAssetRequirementsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetAssetRequirementsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetClaimCountTransferRestrictionsParams/SetClaimCountTransferRestrictionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetClaimCountTransferRestrictionsParams/SetClaimCountTransferRestrictionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetClaimCountTransferRestrictionsParams"
 sidebar_label: "SetClaimCountTransferRestrictionsParams"
 ---
 
-# Interface: SetClaimCountTransferRestrictionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetClaimCountTransferRestrictionsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetClaimPercentageTransferRestrictionsParams/SetClaimPercentageTransferRestrictionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetClaimPercentageTransferRestrictionsParams/SetClaimPercentageTransferRestrictionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetClaimPercentageTransferRestrictionsParams"
 sidebar_label: "SetClaimPercentageTransferRestrictionsParams"
 ---
 
-# Interface: SetClaimPercentageTransferRestrictionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetClaimPercentageTransferRestrictionsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetCountTransferRestrictionsParams/SetCountTransferRestrictionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetCountTransferRestrictionsParams/SetCountTransferRestrictionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetCountTransferRestrictionsParams"
 sidebar_label: "SetCountTransferRestrictionsParams"
 ---
 
-# Interface: SetCountTransferRestrictionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetCountTransferRestrictionsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetCustodianParams/SetCustodianParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetCustodianParams/SetCustodianParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetCustodianParams"
 sidebar_label: "SetCustodianParams"
 ---
 
-# Interface: SetCustodianParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetCustodianParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetGroupPermissionsParams/SetGroupPermissionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetGroupPermissionsParams/SetGroupPermissionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetGroupPermissionsParams"
 sidebar_label: "SetGroupPermissionsParams"
 ---
 
-# Interface: SetGroupPermissionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetGroupPermissionsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetPercentageTransferRestrictionsParams/SetPercentageTransferRestrictionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetPercentageTransferRestrictionsParams/SetPercentageTransferRestrictionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetPercentageTransferRestrictionsParams"
 sidebar_label: "SetPercentageTransferRestrictionsParams"
 ---
 
-# Interface: SetPercentageTransferRestrictionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetPercentageTransferRestrictionsParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/SetPermissionGroupParams/SetPermissionGroupParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SetPermissionGroupParams/SetPermissionGroupParams.md
@@ -4,8 +4,6 @@ title: "Interface: SetPermissionGroupParams"
 sidebar_label: "SetPermissionGroupParams"
 ---
 
-# Interface: SetPermissionGroupParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SetPermissionGroupParams
 
 This procedure can be called with:

--- a/sdk-docs/interfaces/API/Procedures/Types/SubsidizeAccountParams/SubsidizeAccountParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/SubsidizeAccountParams/SubsidizeAccountParams.md
@@ -4,8 +4,6 @@ title: "Interface: SubsidizeAccountParams"
 sidebar_label: "SubsidizeAccountParams"
 ---
 
-# Interface: SubsidizeAccountParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).SubsidizeAccountParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/TransactionsParams/TransactionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/TransactionsParams/TransactionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: TransactionsParams"
 sidebar_label: "TransactionsParams"
 ---
 
-# Interface: TransactionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).TransactionsParams
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/TransferAssetOwnershipParams/TransferAssetOwnershipParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/TransferAssetOwnershipParams/TransferAssetOwnershipParams.md
@@ -4,8 +4,6 @@ title: "Interface: TransferAssetOwnershipParams"
 sidebar_label: "TransferAssetOwnershipParams"
 ---
 
-# Interface: TransferAssetOwnershipParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).TransferAssetOwnershipParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/TransferPolyxParams/TransferPolyxParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/TransferPolyxParams/TransferPolyxParams.md
@@ -4,8 +4,6 @@ title: "Interface: TransferPolyxParams"
 sidebar_label: "TransferPolyxParams"
 ---
 
-# Interface: TransferPolyxParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).TransferPolyxParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/TransferRestriction/TransferRestriction.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/TransferRestriction/TransferRestriction.md
@@ -4,8 +4,6 @@ title: "Interface: TransferRestriction"
 sidebar_label: "TransferRestriction"
 ---
 
-# Interface: TransferRestriction
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).TransferRestriction
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/TransferTickerOwnershipParams/TransferTickerOwnershipParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/TransferTickerOwnershipParams/TransferTickerOwnershipParams.md
@@ -4,8 +4,6 @@ title: "Interface: TransferTickerOwnershipParams"
 sidebar_label: "TransferTickerOwnershipParams"
 ---
 
-# Interface: TransferTickerOwnershipParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).TransferTickerOwnershipParams
 
 ## Properties

--- a/sdk-docs/interfaces/API/Procedures/Types/TxGroupParams/TxGroupParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/TxGroupParams/TxGroupParams.md
@@ -4,8 +4,6 @@ title: "Interface: TxGroupParams"
 sidebar_label: "TxGroupParams"
 ---
 
-# Interface: TxGroupParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).TxGroupParams
 
 ## Hierarchy

--- a/sdk-docs/interfaces/API/Procedures/Types/WaivePermissionsParams/WaivePermissionsParams.md
+++ b/sdk-docs/interfaces/API/Procedures/Types/WaivePermissionsParams/WaivePermissionsParams.md
@@ -4,8 +4,6 @@ title: "Interface: WaivePermissionsParams"
 sidebar_label: "WaivePermissionsParams"
 ---
 
-# Interface: WaivePermissionsParams
-
 [api/procedures/types](../../../../../modules/API/Procedures/Types/Types.md).WaivePermissionsParams
 
 ## Properties

--- a/sdk-docs/interfaces/Types/AccreditedClaim/AccreditedClaim.md
+++ b/sdk-docs/interfaces/Types/AccreditedClaim/AccreditedClaim.md
@@ -4,8 +4,6 @@ title: "Interface: AccreditedClaim"
 sidebar_label: "AccreditedClaim"
 ---
 
-# Interface: AccreditedClaim
-
 [types](../../../modules/Types/Types.md).AccreditedClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ActiveTransferRestrictions/ActiveTransferRestrictions.md
+++ b/sdk-docs/interfaces/Types/ActiveTransferRestrictions/ActiveTransferRestrictions.md
@@ -4,8 +4,6 @@ title: "Interface: ActiveTransferRestrictions<Restriction>"
 sidebar_label: "ActiveTransferRestrictions"
 ---
 
-# Interface: ActiveTransferRestrictions<Restriction\>
-
 [types](../../../modules/Types/Types.md).ActiveTransferRestrictions
 
 ## Type parameters

--- a/sdk-docs/interfaces/Types/AddCountStatInput/AddCountStatInput.md
+++ b/sdk-docs/interfaces/Types/AddCountStatInput/AddCountStatInput.md
@@ -4,8 +4,6 @@ title: "Interface: AddCountStatInput"
 sidebar_label: "AddCountStatInput"
 ---
 
-# Interface: AddCountStatInput
-
 [types](../../../modules/Types/Types.md).AddCountStatInput
 
 ## Properties

--- a/sdk-docs/interfaces/Types/AffiliateClaim/AffiliateClaim.md
+++ b/sdk-docs/interfaces/Types/AffiliateClaim/AffiliateClaim.md
@@ -4,8 +4,6 @@ title: "Interface: AffiliateClaim"
 sidebar_label: "AffiliateClaim"
 ---
 
-# Interface: AffiliateClaim
-
 [types](../../../modules/Types/Types.md).AffiliateClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ArrayTransactionArgument/ArrayTransactionArgument.md
+++ b/sdk-docs/interfaces/Types/ArrayTransactionArgument/ArrayTransactionArgument.md
@@ -4,8 +4,6 @@ title: "Interface: ArrayTransactionArgument"
 sidebar_label: "ArrayTransactionArgument"
 ---
 
-# Interface: ArrayTransactionArgument
-
 [types](../../../modules/Types/Types.md).ArrayTransactionArgument
 
 ## Properties

--- a/sdk-docs/interfaces/Types/AssetDocument/AssetDocument.md
+++ b/sdk-docs/interfaces/Types/AssetDocument/AssetDocument.md
@@ -4,8 +4,6 @@ title: "Interface: AssetDocument"
 sidebar_label: "AssetDocument"
 ---
 
-# Interface: AssetDocument
-
 [types](../../../modules/Types/Types.md).AssetDocument
 
 Document attached to a token

--- a/sdk-docs/interfaces/Types/AssetWithGroup/AssetWithGroup.md
+++ b/sdk-docs/interfaces/Types/AssetWithGroup/AssetWithGroup.md
@@ -4,8 +4,6 @@ title: "Interface: AssetWithGroup"
 sidebar_label: "AssetWithGroup"
 ---
 
-# Interface: AssetWithGroup
-
 [types](../../../modules/Types/Types.md).AssetWithGroup
 
 ## Properties

--- a/sdk-docs/interfaces/Types/Balance/Balance.md
+++ b/sdk-docs/interfaces/Types/Balance/Balance.md
@@ -4,8 +4,6 @@ title: "Interface: Balance"
 sidebar_label: "Balance"
 ---
 
-# Interface: Balance
-
 [types](../../../modules/Types/Types.md).Balance
 
 ## Hierarchy

--- a/sdk-docs/interfaces/Types/BlockedClaim/BlockedClaim.md
+++ b/sdk-docs/interfaces/Types/BlockedClaim/BlockedClaim.md
@@ -4,8 +4,6 @@ title: "Interface: BlockedClaim"
 sidebar_label: "BlockedClaim"
 ---
 
-# Interface: BlockedClaim
-
 [types](../../../modules/Types/Types.md).BlockedClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/BuyLockupClaim/BuyLockupClaim.md
+++ b/sdk-docs/interfaces/Types/BuyLockupClaim/BuyLockupClaim.md
@@ -4,8 +4,6 @@ title: "Interface: BuyLockupClaim"
 sidebar_label: "BuyLockupClaim"
 ---
 
-# Interface: BuyLockupClaim
-
 [types](../../../modules/Types/Types.md).BuyLockupClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/CalendarPeriod/CalendarPeriod.md
+++ b/sdk-docs/interfaces/Types/CalendarPeriod/CalendarPeriod.md
@@ -4,8 +4,6 @@ title: "Interface: CalendarPeriod"
 sidebar_label: "CalendarPeriod"
 ---
 
-# Interface: CalendarPeriod
-
 [types](../../../modules/Types/Types.md).CalendarPeriod
 
 Represents a period of time measured in a specific unit (e.g. 20 days)

--- a/sdk-docs/interfaces/Types/CddClaim/CddClaim.md
+++ b/sdk-docs/interfaces/Types/CddClaim/CddClaim.md
@@ -4,8 +4,6 @@ title: "Interface: CddClaim"
 sidebar_label: "CddClaim"
 ---
 
-# Interface: CddClaim
-
 [types](../../../modules/Types/Types.md).CddClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/CddProviderRole/CddProviderRole.md
+++ b/sdk-docs/interfaces/Types/CddProviderRole/CddProviderRole.md
@@ -4,8 +4,6 @@ title: "Interface: CddProviderRole"
 sidebar_label: "CddProviderRole"
 ---
 
-# Interface: CddProviderRole
-
 [types](../../../modules/Types/Types.md).CddProviderRole
 
 ## Properties

--- a/sdk-docs/interfaces/Types/CheckPermissionsResult/CheckPermissionsResult.md
+++ b/sdk-docs/interfaces/Types/CheckPermissionsResult/CheckPermissionsResult.md
@@ -4,8 +4,6 @@ title: "Interface: CheckPermissionsResult<Type>"
 sidebar_label: "CheckPermissionsResult"
 ---
 
-# Interface: CheckPermissionsResult<Type\>
-
 [types](../../../modules/Types/Types.md).CheckPermissionsResult
 
 Result of a `checkPermissions` call. If `Type` is `Account`, represents whether the Account

--- a/sdk-docs/interfaces/Types/CheckRolesResult/CheckRolesResult.md
+++ b/sdk-docs/interfaces/Types/CheckRolesResult/CheckRolesResult.md
@@ -4,8 +4,6 @@ title: "Interface: CheckRolesResult"
 sidebar_label: "CheckRolesResult"
 ---
 
-# Interface: CheckRolesResult
-
 [types](../../../modules/Types/Types.md).CheckRolesResult
 
 Result of a `checkRoles` call

--- a/sdk-docs/interfaces/Types/CheckpointWithData/CheckpointWithData.md
+++ b/sdk-docs/interfaces/Types/CheckpointWithData/CheckpointWithData.md
@@ -4,8 +4,6 @@ title: "Interface: CheckpointWithData"
 sidebar_label: "CheckpointWithData"
 ---
 
-# Interface: CheckpointWithData
-
 [types](../../../modules/Types/Types.md).CheckpointWithData
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ClaimCountRestrictionValue/ClaimCountRestrictionValue.md
+++ b/sdk-docs/interfaces/Types/ClaimCountRestrictionValue/ClaimCountRestrictionValue.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimCountRestrictionValue"
 sidebar_label: "ClaimCountRestrictionValue"
 ---
 
-# Interface: ClaimCountRestrictionValue
-
 [types](../../../modules/Types/Types.md).ClaimCountRestrictionValue
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ClaimCountTransferRestriction/ClaimCountTransferRestriction.md
+++ b/sdk-docs/interfaces/Types/ClaimCountTransferRestriction/ClaimCountTransferRestriction.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimCountTransferRestriction"
 sidebar_label: "ClaimCountTransferRestriction"
 ---
 
-# Interface: ClaimCountTransferRestriction
-
 [types](../../../modules/Types/Types.md).ClaimCountTransferRestriction
 
 ## Hierarchy

--- a/sdk-docs/interfaces/Types/ClaimData/ClaimData.md
+++ b/sdk-docs/interfaces/Types/ClaimData/ClaimData.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimData<ClaimType>"
 sidebar_label: "ClaimData"
 ---
 
-# Interface: ClaimData<ClaimType\>
-
 [types](../../../modules/Types/Types.md).ClaimData
 
 ## Type parameters

--- a/sdk-docs/interfaces/Types/ClaimPercentageRestrictionValue/ClaimPercentageRestrictionValue.md
+++ b/sdk-docs/interfaces/Types/ClaimPercentageRestrictionValue/ClaimPercentageRestrictionValue.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimPercentageRestrictionValue"
 sidebar_label: "ClaimPercentageRestrictionValue"
 ---
 
-# Interface: ClaimPercentageRestrictionValue
-
 [types](../../../modules/Types/Types.md).ClaimPercentageRestrictionValue
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ClaimPercentageTransferRestriction/ClaimPercentageTransferRestriction.md
+++ b/sdk-docs/interfaces/Types/ClaimPercentageTransferRestriction/ClaimPercentageTransferRestriction.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimPercentageTransferRestriction"
 sidebar_label: "ClaimPercentageTransferRestriction"
 ---
 
-# Interface: ClaimPercentageTransferRestriction
-
 [types](../../../modules/Types/Types.md).ClaimPercentageTransferRestriction
 
 ## Hierarchy

--- a/sdk-docs/interfaces/Types/ClaimScope/ClaimScope.md
+++ b/sdk-docs/interfaces/Types/ClaimScope/ClaimScope.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimScope"
 sidebar_label: "ClaimScope"
 ---
 
-# Interface: ClaimScope
-
 [types](../../../modules/Types/Types.md).ClaimScope
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ClaimTarget/ClaimTarget.md
+++ b/sdk-docs/interfaces/Types/ClaimTarget/ClaimTarget.md
@@ -4,8 +4,6 @@ title: "Interface: ClaimTarget"
 sidebar_label: "ClaimTarget"
 ---
 
-# Interface: ClaimTarget
-
 [types](../../../modules/Types/Types.md).ClaimTarget
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ComplexTransactionArgument/ComplexTransactionArgument.md
+++ b/sdk-docs/interfaces/Types/ComplexTransactionArgument/ComplexTransactionArgument.md
@@ -4,8 +4,6 @@ title: "Interface: ComplexTransactionArgument"
 sidebar_label: "ComplexTransactionArgument"
 ---
 
-# Interface: ComplexTransactionArgument
-
 [types](../../../modules/Types/Types.md).ComplexTransactionArgument
 
 ## Properties

--- a/sdk-docs/interfaces/Types/Compliance/Compliance.md
+++ b/sdk-docs/interfaces/Types/Compliance/Compliance.md
@@ -4,8 +4,6 @@ title: "Interface: Compliance"
 sidebar_label: "Compliance"
 ---
 
-# Interface: Compliance
-
 [types](../../../modules/Types/Types.md).Compliance
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ComplianceRequirements/ComplianceRequirements.md
+++ b/sdk-docs/interfaces/Types/ComplianceRequirements/ComplianceRequirements.md
@@ -4,8 +4,6 @@ title: "Interface: ComplianceRequirements"
 sidebar_label: "ComplianceRequirements"
 ---
 
-# Interface: ComplianceRequirements
-
 [types](../../../modules/Types/Types.md).ComplianceRequirements
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ConditionBase/ConditionBase.md
+++ b/sdk-docs/interfaces/Types/ConditionBase/ConditionBase.md
@@ -4,8 +4,6 @@ title: "Interface: ConditionBase"
 sidebar_label: "ConditionBase"
 ---
 
-# Interface: ConditionBase
-
 [types](../../../modules/Types/Types.md).ConditionBase
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ConditionCompliance/ConditionCompliance.md
+++ b/sdk-docs/interfaces/Types/ConditionCompliance/ConditionCompliance.md
@@ -4,8 +4,6 @@ title: "Interface: ConditionCompliance"
 sidebar_label: "ConditionCompliance"
 ---
 
-# Interface: ConditionCompliance
-
 [types](../../../modules/Types/Types.md).ConditionCompliance
 
 ## Properties

--- a/sdk-docs/interfaces/Types/CountTransferRestriction/CountTransferRestriction.md
+++ b/sdk-docs/interfaces/Types/CountTransferRestriction/CountTransferRestriction.md
@@ -4,8 +4,6 @@ title: "Interface: CountTransferRestriction"
 sidebar_label: "CountTransferRestriction"
 ---
 
-# Interface: CountTransferRestriction
-
 [types](../../../modules/Types/Types.md).CountTransferRestriction
 
 ## Hierarchy

--- a/sdk-docs/interfaces/Types/CreateTransactionBatchProcedureMethod/CreateTransactionBatchProcedureMethod.md
+++ b/sdk-docs/interfaces/Types/CreateTransactionBatchProcedureMethod/CreateTransactionBatchProcedureMethod.md
@@ -4,8 +4,6 @@ title: "Interface: CreateTransactionBatchProcedureMethod"
 sidebar_label: "CreateTransactionBatchProcedureMethod"
 ---
 
-# Interface: CreateTransactionBatchProcedureMethod
-
 [types](../../../modules/Types/Types.md).CreateTransactionBatchProcedureMethod
 
 ## Callable

--- a/sdk-docs/interfaces/Types/DistributionPayment/DistributionPayment.md
+++ b/sdk-docs/interfaces/Types/DistributionPayment/DistributionPayment.md
@@ -4,8 +4,6 @@ title: "Interface: DistributionPayment"
 sidebar_label: "DistributionPayment"
 ---
 
-# Interface: DistributionPayment
-
 [types](../../../modules/Types/Types.md).DistributionPayment
 
 ## Properties

--- a/sdk-docs/interfaces/Types/DistributionWithDetails/DistributionWithDetails.md
+++ b/sdk-docs/interfaces/Types/DistributionWithDetails/DistributionWithDetails.md
@@ -4,8 +4,6 @@ title: "Interface: DistributionWithDetails"
 sidebar_label: "DistributionWithDetails"
 ---
 
-# Interface: DistributionWithDetails
-
 [types](../../../modules/Types/Types.md).DistributionWithDetails
 
 ## Properties

--- a/sdk-docs/interfaces/Types/EventIdentifier/EventIdentifier.md
+++ b/sdk-docs/interfaces/Types/EventIdentifier/EventIdentifier.md
@@ -4,8 +4,6 @@ title: "Interface: EventIdentifier"
 sidebar_label: "EventIdentifier"
 ---
 
-# Interface: EventIdentifier
-
 [types](../../../modules/Types/Types.md).EventIdentifier
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ExemptedClaim/ExemptedClaim.md
+++ b/sdk-docs/interfaces/Types/ExemptedClaim/ExemptedClaim.md
@@ -4,8 +4,6 @@ title: "Interface: ExemptedClaim"
 sidebar_label: "ExemptedClaim"
 ---
 
-# Interface: ExemptedClaim
-
 [types](../../../modules/Types/Types.md).ExemptedClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ExternalAgentCondition/ExternalAgentCondition.md
+++ b/sdk-docs/interfaces/Types/ExternalAgentCondition/ExternalAgentCondition.md
@@ -4,8 +4,6 @@ title: "Interface: ExternalAgentCondition"
 sidebar_label: "ExternalAgentCondition"
 ---
 
-# Interface: ExternalAgentCondition
-
 [types](../../../modules/Types/Types.md).ExternalAgentCondition
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ExtrinsicData/ExtrinsicData.md
+++ b/sdk-docs/interfaces/Types/ExtrinsicData/ExtrinsicData.md
@@ -4,8 +4,6 @@ title: "Interface: ExtrinsicData"
 sidebar_label: "ExtrinsicData"
 ---
 
-# Interface: ExtrinsicData
-
 [types](../../../modules/Types/Types.md).ExtrinsicData
 
 ## Hierarchy

--- a/sdk-docs/interfaces/Types/ExtrinsicDataWithFees/ExtrinsicDataWithFees.md
+++ b/sdk-docs/interfaces/Types/ExtrinsicDataWithFees/ExtrinsicDataWithFees.md
@@ -4,8 +4,6 @@ title: "Interface: ExtrinsicDataWithFees"
 sidebar_label: "ExtrinsicDataWithFees"
 ---
 
-# Interface: ExtrinsicDataWithFees
-
 [types](../../../modules/Types/Types.md).ExtrinsicDataWithFees
 
 ## Hierarchy

--- a/sdk-docs/interfaces/Types/Fees/Fees.md
+++ b/sdk-docs/interfaces/Types/Fees/Fees.md
@@ -4,8 +4,6 @@ title: "Interface: Fees"
 sidebar_label: "Fees"
 ---
 
-# Interface: Fees
-
 [types](../../../modules/Types/Types.md).Fees
 
 ## Properties

--- a/sdk-docs/interfaces/Types/GroupedInstructions/GroupedInstructions.md
+++ b/sdk-docs/interfaces/Types/GroupedInstructions/GroupedInstructions.md
@@ -4,8 +4,6 @@ title: "Interface: GroupedInstructions"
 sidebar_label: "GroupedInstructions"
 ---
 
-# Interface: GroupedInstructions
-
 [types](../../../modules/Types/Types.md).GroupedInstructions
 
 ## Properties

--- a/sdk-docs/interfaces/Types/HistoricAgentOperation/HistoricAgentOperation.md
+++ b/sdk-docs/interfaces/Types/HistoricAgentOperation/HistoricAgentOperation.md
@@ -4,8 +4,6 @@ title: "Interface: HistoricAgentOperation"
 sidebar_label: "HistoricAgentOperation"
 ---
 
-# Interface: HistoricAgentOperation
-
 [types](../../../modules/Types/Types.md).HistoricAgentOperation
 
 Events triggered by transactions performed by an Agent Identity, related to the Token's configuration

--- a/sdk-docs/interfaces/Types/IdentityCondition/IdentityCondition.md
+++ b/sdk-docs/interfaces/Types/IdentityCondition/IdentityCondition.md
@@ -4,8 +4,6 @@ title: "Interface: IdentityCondition"
 sidebar_label: "IdentityCondition"
 ---
 
-# Interface: IdentityCondition
-
 [types](../../../modules/Types/Types.md).IdentityCondition
 
 ## Properties

--- a/sdk-docs/interfaces/Types/IdentityRole/IdentityRole.md
+++ b/sdk-docs/interfaces/Types/IdentityRole/IdentityRole.md
@@ -4,8 +4,6 @@ title: "Interface: IdentityRole"
 sidebar_label: "IdentityRole"
 ---
 
-# Interface: IdentityRole
-
 [types](../../../modules/Types/Types.md).IdentityRole
 
 ## Properties

--- a/sdk-docs/interfaces/Types/IdentityWithClaims/IdentityWithClaims.md
+++ b/sdk-docs/interfaces/Types/IdentityWithClaims/IdentityWithClaims.md
@@ -4,8 +4,6 @@ title: "Interface: IdentityWithClaims"
 sidebar_label: "IdentityWithClaims"
 ---
 
-# Interface: IdentityWithClaims
-
 [types](../../../modules/Types/Types.md).IdentityWithClaims
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ImmortalProcedureOptValue/ImmortalProcedureOptValue.md
+++ b/sdk-docs/interfaces/Types/ImmortalProcedureOptValue/ImmortalProcedureOptValue.md
@@ -4,8 +4,6 @@ title: "Interface: ImmortalProcedureOptValue"
 sidebar_label: "ImmortalProcedureOptValue"
 ---
 
-# Interface: ImmortalProcedureOptValue
-
 [types](../../../modules/Types/Types.md).ImmortalProcedureOptValue
 
 This transaction will never expire

--- a/sdk-docs/interfaces/Types/InvestorUniquenessClaim/InvestorUniquenessClaim.md
+++ b/sdk-docs/interfaces/Types/InvestorUniquenessClaim/InvestorUniquenessClaim.md
@@ -4,8 +4,6 @@ title: "Interface: InvestorUniquenessClaim"
 sidebar_label: "InvestorUniquenessClaim"
 ---
 
-# Interface: InvestorUniquenessClaim
-
 [types](../../../modules/Types/Types.md).InvestorUniquenessClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/InvestorUniquenessV2Claim/InvestorUniquenessV2Claim.md
+++ b/sdk-docs/interfaces/Types/InvestorUniquenessV2Claim/InvestorUniquenessV2Claim.md
@@ -4,8 +4,6 @@ title: "Interface: InvestorUniquenessV2Claim"
 sidebar_label: "InvestorUniquenessV2Claim"
 ---
 
-# Interface: InvestorUniquenessV2Claim
-
 [types](../../../modules/Types/Types.md).InvestorUniquenessV2Claim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/JurisdictionClaim/JurisdictionClaim.md
+++ b/sdk-docs/interfaces/Types/JurisdictionClaim/JurisdictionClaim.md
@@ -4,8 +4,6 @@ title: "Interface: JurisdictionClaim"
 sidebar_label: "JurisdictionClaim"
 ---
 
-# Interface: JurisdictionClaim
-
 [types](../../../modules/Types/Types.md).JurisdictionClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/KycClaim/KycClaim.md
+++ b/sdk-docs/interfaces/Types/KycClaim/KycClaim.md
@@ -4,8 +4,6 @@ title: "Interface: KycClaim"
 sidebar_label: "KycClaim"
 ---
 
-# Interface: KycClaim
-
 [types](../../../modules/Types/Types.md).KycClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/MiddlewareConfig/MiddlewareConfig.md
+++ b/sdk-docs/interfaces/Types/MiddlewareConfig/MiddlewareConfig.md
@@ -4,8 +4,6 @@ title: "Interface: MiddlewareConfig"
 sidebar_label: "MiddlewareConfig"
 ---
 
-# Interface: MiddlewareConfig
-
 [types](../../../modules/Types/Types.md).MiddlewareConfig
 
 ## Properties

--- a/sdk-docs/interfaces/Types/MortalProcedureOptValue/MortalProcedureOptValue.md
+++ b/sdk-docs/interfaces/Types/MortalProcedureOptValue/MortalProcedureOptValue.md
@@ -4,8 +4,6 @@ title: "Interface: MortalProcedureOptValue"
 sidebar_label: "MortalProcedureOptValue"
 ---
 
-# Interface: MortalProcedureOptValue
-
 [types](../../../modules/Types/Types.md).MortalProcedureOptValue
 
 This transaction will be rejected if not included in a block after a while (default: ~5 minutes)

--- a/sdk-docs/interfaces/Types/MultiClaimCondition/MultiClaimCondition.md
+++ b/sdk-docs/interfaces/Types/MultiClaimCondition/MultiClaimCondition.md
@@ -4,8 +4,6 @@ title: "Interface: MultiClaimCondition"
 sidebar_label: "MultiClaimCondition"
 ---
 
-# Interface: MultiClaimCondition
-
 [types](../../../modules/Types/Types.md).MultiClaimCondition
 
 ## Properties

--- a/sdk-docs/interfaces/Types/NetworkProperties/NetworkProperties.md
+++ b/sdk-docs/interfaces/Types/NetworkProperties/NetworkProperties.md
@@ -4,8 +4,6 @@ title: "Interface: NetworkProperties"
 sidebar_label: "NetworkProperties"
 ---
 
-# Interface: NetworkProperties
-
 [types](../../../modules/Types/Types.md).NetworkProperties
 
 ## Properties

--- a/sdk-docs/interfaces/Types/NoArgsProcedureMethod/NoArgsProcedureMethod.md
+++ b/sdk-docs/interfaces/Types/NoArgsProcedureMethod/NoArgsProcedureMethod.md
@@ -4,8 +4,6 @@ title: "Interface: NoArgsProcedureMethod<ProcedureReturnValue, ReturnValue>"
 sidebar_label: "NoArgsProcedureMethod"
 ---
 
-# Interface: NoArgsProcedureMethod<ProcedureReturnValue, ReturnValue\>
-
 [types](../../../modules/Types/Types.md).NoArgsProcedureMethod
 
 ## Type parameters

--- a/sdk-docs/interfaces/Types/NoDataClaim/NoDataClaim.md
+++ b/sdk-docs/interfaces/Types/NoDataClaim/NoDataClaim.md
@@ -4,8 +4,6 @@ title: "Interface: NoDataClaim"
 sidebar_label: "NoDataClaim"
 ---
 
-# Interface: NoDataClaim
-
 [types](../../../modules/Types/Types.md).NoDataClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/NoTypeClaim/NoTypeClaim.md
+++ b/sdk-docs/interfaces/Types/NoTypeClaim/NoTypeClaim.md
@@ -4,8 +4,6 @@ title: "Interface: NoTypeClaim"
 sidebar_label: "NoTypeClaim"
 ---
 
-# Interface: NoTypeClaim
-
 [types](../../../modules/Types/Types.md).NoTypeClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/OfferingWithDetails/OfferingWithDetails.md
+++ b/sdk-docs/interfaces/Types/OfferingWithDetails/OfferingWithDetails.md
@@ -4,8 +4,6 @@ title: "Interface: OfferingWithDetails"
 sidebar_label: "OfferingWithDetails"
 ---
 
-# Interface: OfferingWithDetails
-
 [types](../../../modules/Types/Types.md).OfferingWithDetails
 
 ## Properties

--- a/sdk-docs/interfaces/Types/PaginationOptions/PaginationOptions.md
+++ b/sdk-docs/interfaces/Types/PaginationOptions/PaginationOptions.md
@@ -4,8 +4,6 @@ title: "Interface: PaginationOptions"
 sidebar_label: "PaginationOptions"
 ---
 
-# Interface: PaginationOptions
-
 [types](../../../modules/Types/Types.md).PaginationOptions
 
 ## Properties

--- a/sdk-docs/interfaces/Types/PayingAccountFees/PayingAccountFees.md
+++ b/sdk-docs/interfaces/Types/PayingAccountFees/PayingAccountFees.md
@@ -4,8 +4,6 @@ title: "Interface: PayingAccountFees"
 sidebar_label: "PayingAccountFees"
 ---
 
-# Interface: PayingAccountFees
-
 [types](../../../modules/Types/Types.md).PayingAccountFees
 
 Breakdown of the fees that will be paid by a specific Account for a transaction, along

--- a/sdk-docs/interfaces/Types/PercentageTransferRestriction/PercentageTransferRestriction.md
+++ b/sdk-docs/interfaces/Types/PercentageTransferRestriction/PercentageTransferRestriction.md
@@ -4,8 +4,6 @@ title: "Interface: PercentageTransferRestriction"
 sidebar_label: "PercentageTransferRestriction"
 ---
 
-# Interface: PercentageTransferRestriction
-
 [types](../../../modules/Types/Types.md).PercentageTransferRestriction
 
 ## Hierarchy

--- a/sdk-docs/interfaces/Types/PermissionGroups/PermissionGroups.md
+++ b/sdk-docs/interfaces/Types/PermissionGroups/PermissionGroups.md
@@ -4,8 +4,6 @@ title: "Interface: PermissionGroups"
 sidebar_label: "PermissionGroups"
 ---
 
-# Interface: PermissionGroups
-
 [types](../../../modules/Types/Types.md).PermissionGroups
 
 All Permission Groups of a specific Asset, separated by `known` and `custom`

--- a/sdk-docs/interfaces/Types/PermissionedAccount/PermissionedAccount.md
+++ b/sdk-docs/interfaces/Types/PermissionedAccount/PermissionedAccount.md
@@ -4,8 +4,6 @@ title: "Interface: PermissionedAccount"
 sidebar_label: "PermissionedAccount"
 ---
 
-# Interface: PermissionedAccount
-
 [types](../../../modules/Types/Types.md).PermissionedAccount
 
 ## Properties

--- a/sdk-docs/interfaces/Types/Permissions/Permissions.md
+++ b/sdk-docs/interfaces/Types/Permissions/Permissions.md
@@ -4,8 +4,6 @@ title: "Interface: Permissions"
 sidebar_label: "Permissions"
 ---
 
-# Interface: Permissions
-
 [types](../../../modules/Types/Types.md).Permissions
 
 Permissions a Secondary Key has over the Identity. A null value means the key has

--- a/sdk-docs/interfaces/Types/PlainTransactionArgument/PlainTransactionArgument.md
+++ b/sdk-docs/interfaces/Types/PlainTransactionArgument/PlainTransactionArgument.md
@@ -4,8 +4,6 @@ title: "Interface: PlainTransactionArgument"
 sidebar_label: "PlainTransactionArgument"
 ---
 
-# Interface: PlainTransactionArgument
-
 [types](../../../modules/Types/Types.md).PlainTransactionArgument
 
 ## Properties

--- a/sdk-docs/interfaces/Types/PortfolioCustodianRole/PortfolioCustodianRole.md
+++ b/sdk-docs/interfaces/Types/PortfolioCustodianRole/PortfolioCustodianRole.md
@@ -4,8 +4,6 @@ title: "Interface: PortfolioCustodianRole"
 sidebar_label: "PortfolioCustodianRole"
 ---
 
-# Interface: PortfolioCustodianRole
-
 [types](../../../modules/Types/Types.md).PortfolioCustodianRole
 
 ## Properties

--- a/sdk-docs/interfaces/Types/PortfolioId/PortfolioId.md
+++ b/sdk-docs/interfaces/Types/PortfolioId/PortfolioId.md
@@ -4,8 +4,6 @@ title: "Interface: PortfolioId"
 sidebar_label: "PortfolioId"
 ---
 
-# Interface: PortfolioId
-
 [types](../../../modules/Types/Types.md).PortfolioId
 
 ## Properties

--- a/sdk-docs/interfaces/Types/PortfolioMovement/PortfolioMovement.md
+++ b/sdk-docs/interfaces/Types/PortfolioMovement/PortfolioMovement.md
@@ -4,8 +4,6 @@ title: "Interface: PortfolioMovement"
 sidebar_label: "PortfolioMovement"
 ---
 
-# Interface: PortfolioMovement
-
 [types](../../../modules/Types/Types.md).PortfolioMovement
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ProcedureAuthorizationStatus/ProcedureAuthorizationStatus.md
+++ b/sdk-docs/interfaces/Types/ProcedureAuthorizationStatus/ProcedureAuthorizationStatus.md
@@ -4,8 +4,6 @@ title: "Interface: ProcedureAuthorizationStatus"
 sidebar_label: "ProcedureAuthorizationStatus"
 ---
 
-# Interface: ProcedureAuthorizationStatus
-
 [types](../../../modules/Types/Types.md).ProcedureAuthorizationStatus
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ProcedureMethod/ProcedureMethod.md
+++ b/sdk-docs/interfaces/Types/ProcedureMethod/ProcedureMethod.md
@@ -4,8 +4,6 @@ title: "Interface: ProcedureMethod<MethodArgs, ProcedureReturnValue, ReturnValue
 sidebar_label: "ProcedureMethod"
 ---
 
-# Interface: ProcedureMethod<MethodArgs, ProcedureReturnValue, ReturnValue\>
-
 [types](../../../modules/Types/Types.md).ProcedureMethod
 
 ## Type parameters

--- a/sdk-docs/interfaces/Types/ProcedureOpts/ProcedureOpts.md
+++ b/sdk-docs/interfaces/Types/ProcedureOpts/ProcedureOpts.md
@@ -4,8 +4,6 @@ title: "Interface: ProcedureOpts"
 sidebar_label: "ProcedureOpts"
 ---
 
-# Interface: ProcedureOpts
-
 [types](../../../modules/Types/Types.md).ProcedureOpts
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ProtocolFees/ProtocolFees.md
+++ b/sdk-docs/interfaces/Types/ProtocolFees/ProtocolFees.md
@@ -4,8 +4,6 @@ title: "Interface: ProtocolFees"
 sidebar_label: "ProtocolFees"
 ---
 
-# Interface: ProtocolFees
-
 [types](../../../modules/Types/Types.md).ProtocolFees
 
 ## Properties

--- a/sdk-docs/interfaces/Types/Requirement/Requirement.md
+++ b/sdk-docs/interfaces/Types/Requirement/Requirement.md
@@ -4,8 +4,6 @@ title: "Interface: Requirement"
 sidebar_label: "Requirement"
 ---
 
-# Interface: Requirement
-
 [types](../../../modules/Types/Types.md).Requirement
 
 ## Properties

--- a/sdk-docs/interfaces/Types/RequirementCompliance/RequirementCompliance.md
+++ b/sdk-docs/interfaces/Types/RequirementCompliance/RequirementCompliance.md
@@ -4,8 +4,6 @@ title: "Interface: RequirementCompliance"
 sidebar_label: "RequirementCompliance"
 ---
 
-# Interface: RequirementCompliance
-
 [types](../../../modules/Types/Types.md).RequirementCompliance
 
 ## Properties

--- a/sdk-docs/interfaces/Types/ResultSet/ResultSet.md
+++ b/sdk-docs/interfaces/Types/ResultSet/ResultSet.md
@@ -4,8 +4,6 @@ title: "Interface: ResultSet<T>"
 sidebar_label: "ResultSet"
 ---
 
-# Interface: ResultSet<T\>
-
 [types](../../../modules/Types/Types.md).ResultSet
 
 ## Type parameters

--- a/sdk-docs/interfaces/Types/ScheduleWithDetails/ScheduleWithDetails.md
+++ b/sdk-docs/interfaces/Types/ScheduleWithDetails/ScheduleWithDetails.md
@@ -4,8 +4,6 @@ title: "Interface: ScheduleWithDetails"
 sidebar_label: "ScheduleWithDetails"
 ---
 
-# Interface: ScheduleWithDetails
-
 [types](../../../modules/Types/Types.md).ScheduleWithDetails
 
 ## Properties

--- a/sdk-docs/interfaces/Types/Scope/Scope.md
+++ b/sdk-docs/interfaces/Types/Scope/Scope.md
@@ -4,8 +4,6 @@ title: "Interface: Scope"
 sidebar_label: "Scope"
 ---
 
-# Interface: Scope
-
 [types](../../../modules/Types/Types.md).Scope
 
 ## Properties

--- a/sdk-docs/interfaces/Types/SectionPermissions/SectionPermissions.md
+++ b/sdk-docs/interfaces/Types/SectionPermissions/SectionPermissions.md
@@ -4,8 +4,6 @@ title: "Interface: SectionPermissions<T>"
 sidebar_label: "SectionPermissions"
 ---
 
-# Interface: SectionPermissions<T\>
-
 [types](../../../modules/Types/Types.md).SectionPermissions
 
 Signer/agent permissions for a specific type

--- a/sdk-docs/interfaces/Types/SecurityIdentifier/SecurityIdentifier.md
+++ b/sdk-docs/interfaces/Types/SecurityIdentifier/SecurityIdentifier.md
@@ -4,8 +4,6 @@ title: "Interface: SecurityIdentifier"
 sidebar_label: "SecurityIdentifier"
 ---
 
-# Interface: SecurityIdentifier
-
 [types](../../../modules/Types/Types.md).SecurityIdentifier
 
 Alphanumeric standardized security identifier

--- a/sdk-docs/interfaces/Types/SellLockupClaim/SellLockupClaim.md
+++ b/sdk-docs/interfaces/Types/SellLockupClaim/SellLockupClaim.md
@@ -4,8 +4,6 @@ title: "Interface: SellLockupClaim"
 sidebar_label: "SellLockupClaim"
 ---
 
-# Interface: SellLockupClaim
-
 [types](../../../modules/Types/Types.md).SellLockupClaim
 
 ## Properties

--- a/sdk-docs/interfaces/Types/SignerValue/SignerValue.md
+++ b/sdk-docs/interfaces/Types/SignerValue/SignerValue.md
@@ -4,8 +4,6 @@ title: "Interface: SignerValue"
 sidebar_label: "SignerValue"
 ---
 
-# Interface: SignerValue
-
 [types](../../../modules/Types/Types.md).SignerValue
 
 ## Properties

--- a/sdk-docs/interfaces/Types/SimpleEnumTransactionArgument/SimpleEnumTransactionArgument.md
+++ b/sdk-docs/interfaces/Types/SimpleEnumTransactionArgument/SimpleEnumTransactionArgument.md
@@ -4,8 +4,6 @@ title: "Interface: SimpleEnumTransactionArgument"
 sidebar_label: "SimpleEnumTransactionArgument"
 ---
 
-# Interface: SimpleEnumTransactionArgument
-
 [types](../../../modules/Types/Types.md).SimpleEnumTransactionArgument
 
 ## Properties

--- a/sdk-docs/interfaces/Types/SimplePermissions/SimplePermissions.md
+++ b/sdk-docs/interfaces/Types/SimplePermissions/SimplePermissions.md
@@ -4,8 +4,6 @@ title: "Interface: SimplePermissions"
 sidebar_label: "SimplePermissions"
 ---
 
-# Interface: SimplePermissions
-
 [types](../../../modules/Types/Types.md).SimplePermissions
 
 This represents positive permissions (i.e. only "includes"). It is used

--- a/sdk-docs/interfaces/Types/SingleClaimCondition/SingleClaimCondition.md
+++ b/sdk-docs/interfaces/Types/SingleClaimCondition/SingleClaimCondition.md
@@ -4,8 +4,6 @@ title: "Interface: SingleClaimCondition"
 sidebar_label: "SingleClaimCondition"
 ---
 
-# Interface: SingleClaimCondition
-
 [types](../../../modules/Types/Types.md).SingleClaimCondition
 
 ## Properties

--- a/sdk-docs/interfaces/Types/StatAccreditedClaimInput/StatAccreditedClaimInput.md
+++ b/sdk-docs/interfaces/Types/StatAccreditedClaimInput/StatAccreditedClaimInput.md
@@ -4,8 +4,6 @@ title: "Interface: StatAccreditedClaimInput"
 sidebar_label: "StatAccreditedClaimInput"
 ---
 
-# Interface: StatAccreditedClaimInput
-
 [types](../../../modules/Types/Types.md).StatAccreditedClaimInput
 
 ## Properties

--- a/sdk-docs/interfaces/Types/StatAffiliateClaimInput/StatAffiliateClaimInput.md
+++ b/sdk-docs/interfaces/Types/StatAffiliateClaimInput/StatAffiliateClaimInput.md
@@ -4,8 +4,6 @@ title: "Interface: StatAffiliateClaimInput"
 sidebar_label: "StatAffiliateClaimInput"
 ---
 
-# Interface: StatAffiliateClaimInput
-
 [types](../../../modules/Types/Types.md).StatAffiliateClaimInput
 
 ## Properties

--- a/sdk-docs/interfaces/Types/StatClaimIssuer/StatClaimIssuer.md
+++ b/sdk-docs/interfaces/Types/StatClaimIssuer/StatClaimIssuer.md
@@ -4,8 +4,6 @@ title: "Interface: StatClaimIssuer"
 sidebar_label: "StatClaimIssuer"
 ---
 
-# Interface: StatClaimIssuer
-
 [types](../../../modules/Types/Types.md).StatClaimIssuer
 
 ## Properties

--- a/sdk-docs/interfaces/Types/StatJurisdictionClaimInput/StatJurisdictionClaimInput.md
+++ b/sdk-docs/interfaces/Types/StatJurisdictionClaimInput/StatJurisdictionClaimInput.md
@@ -4,8 +4,6 @@ title: "Interface: StatJurisdictionClaimInput"
 sidebar_label: "StatJurisdictionClaimInput"
 ---
 
-# Interface: StatJurisdictionClaimInput
-
 [types](../../../modules/Types/Types.md).StatJurisdictionClaimInput
 
 ## Properties

--- a/sdk-docs/interfaces/Types/TickerOwnerRole/TickerOwnerRole.md
+++ b/sdk-docs/interfaces/Types/TickerOwnerRole/TickerOwnerRole.md
@@ -4,8 +4,6 @@ title: "Interface: TickerOwnerRole"
 sidebar_label: "TickerOwnerRole"
 ---
 
-# Interface: TickerOwnerRole
-
 [types](../../../modules/Types/Types.md).TickerOwnerRole
 
 ## Properties

--- a/sdk-docs/interfaces/Types/TransactionPermissions/TransactionPermissions.md
+++ b/sdk-docs/interfaces/Types/TransactionPermissions/TransactionPermissions.md
@@ -4,8 +4,6 @@ title: "Interface: TransactionPermissions"
 sidebar_label: "TransactionPermissions"
 ---
 
-# Interface: TransactionPermissions
-
 [types](../../../modules/Types/Types.md).TransactionPermissions
 
 Permissions related to Transactions. Can include/exclude individual transactions or entire modules

--- a/sdk-docs/interfaces/Types/TrustedClaimIssuer/TrustedClaimIssuer.md
+++ b/sdk-docs/interfaces/Types/TrustedClaimIssuer/TrustedClaimIssuer.md
@@ -4,8 +4,6 @@ title: "Interface: TrustedClaimIssuer<IsDefault>"
 sidebar_label: "TrustedClaimIssuer"
 ---
 
-# Interface: TrustedClaimIssuer<IsDefault\>
-
 [types](../../../modules/Types/Types.md).TrustedClaimIssuer
 
 ## Type parameters

--- a/sdk-docs/interfaces/Types/TxData/TxData.md
+++ b/sdk-docs/interfaces/Types/TxData/TxData.md
@@ -4,8 +4,6 @@ title: "Interface: TxData<Args>"
 sidebar_label: "TxData"
 ---
 
-# Interface: TxData<Args\>
-
 [types](../../../modules/Types/Types.md).TxData
 
 Transaction data for display purposes

--- a/sdk-docs/interfaces/Types/VenueOwnerRole/VenueOwnerRole.md
+++ b/sdk-docs/interfaces/Types/VenueOwnerRole/VenueOwnerRole.md
@@ -4,8 +4,6 @@ title: "Interface: VenueOwnerRole"
 sidebar_label: "VenueOwnerRole"
 ---
 
-# Interface: VenueOwnerRole
-
 [types](../../../modules/Types/Types.md).VenueOwnerRole
 
 ## Properties

--- a/sdk-docs/moduleList.md
+++ b/sdk-docs/moduleList.md
@@ -1,11 +1,9 @@
 ---
 id: 'moduleList'
-title: '@polymeshassociation/polymesh-sdk'
+title: 'Polymesh SDK API Documents'
 sidebar_label: 'SDK Module List'
-sidebar_position: 0
+sidebar_position: 0.5
 ---
-
-# @polymeshassociation/polymesh-sdk
 
 ## Modules
 

--- a/sdk-docs/modules/API/Client/AccountManagement/AccountManagement.md
+++ b/sdk-docs/modules/API/Client/AccountManagement/AccountManagement.md
@@ -1,10 +1,8 @@
 ---
 id: "AccountManagement"
-title: "Module: api/client/AccountManagement"
+title: "Module: AccountManagement"
 sidebar_label: "AccountManagement"
 ---
-
-# Module: api/client/AccountManagement
 
 ## Classes
 

--- a/sdk-docs/modules/API/Client/Assets/Assets.md
+++ b/sdk-docs/modules/API/Client/Assets/Assets.md
@@ -1,10 +1,8 @@
 ---
 id: "Assets"
-title: "Module: api/client/Assets"
+title: "Module: Assets"
 sidebar_label: "Assets"
 ---
-
-# Module: api/client/Assets
 
 ## Classes
 

--- a/sdk-docs/modules/API/Client/Claims/Claims.md
+++ b/sdk-docs/modules/API/Client/Claims/Claims.md
@@ -1,10 +1,8 @@
 ---
 id: "Claims"
-title: "Module: api/client/Claims"
+title: "Module: Claims"
 sidebar_label: "Claims"
 ---
-
-# Module: api/client/Claims
 
 ## Classes
 

--- a/sdk-docs/modules/API/Client/Identities/Identities.md
+++ b/sdk-docs/modules/API/Client/Identities/Identities.md
@@ -1,10 +1,8 @@
 ---
 id: "Identities"
-title: "Module: api/client/Identities"
+title: "Module: Identities"
 sidebar_label: "Identities"
 ---
-
-# Module: api/client/Identities
 
 ## Classes
 

--- a/sdk-docs/modules/API/Client/Network/Network.md
+++ b/sdk-docs/modules/API/Client/Network/Network.md
@@ -1,10 +1,8 @@
 ---
 id: "Network"
-title: "Module: api/client/Network"
+title: "Module: Network"
 sidebar_label: "Network"
 ---
-
-# Module: api/client/Network
 
 ## Classes
 

--- a/sdk-docs/modules/API/Client/Polymesh/Polymesh.md
+++ b/sdk-docs/modules/API/Client/Polymesh/Polymesh.md
@@ -1,10 +1,8 @@
 ---
 id: "Polymesh"
-title: "Module: api/client/Polymesh"
+title: "Module: Polymesh"
 sidebar_label: "Polymesh"
 ---
-
-# Module: api/client/Polymesh
 
 ## Classes
 

--- a/sdk-docs/modules/API/Client/Settlements/Settlements.md
+++ b/sdk-docs/modules/API/Client/Settlements/Settlements.md
@@ -1,10 +1,8 @@
 ---
 id: "Settlements"
-title: "Module: api/client/Settlements"
+title: "Module: Settlements"
 sidebar_label: "Settlements"
 ---
-
-# Module: api/client/Settlements
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Account/Account.md
+++ b/sdk-docs/modules/API/Entities/Account/Account.md
@@ -1,10 +1,8 @@
 ---
 id: "Account"
-title: "Module: api/entities/Account"
+title: "Module: Account"
 sidebar_label: "Account"
 ---
-
-# Module: api/entities/Account
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Asset.md
+++ b/sdk-docs/modules/API/Entities/Asset/Asset.md
@@ -1,10 +1,8 @@
 ---
 id: "Asset"
-title: "Module: api/entities/Asset"
+title: "Module: Asset"
 sidebar_label: "Asset"
 ---
-
-# Module: api/entities/Asset
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/AssetHolders/AssetHolders.md
+++ b/sdk-docs/modules/API/Entities/Asset/AssetHolders/AssetHolders.md
@@ -1,10 +1,8 @@
 ---
 id: "AssetHolders"
-title: "Module: api/entities/Asset/AssetHolders"
+title: "Module: AssetHolders"
 sidebar_label: "AssetHolders"
 ---
-
-# Module: api/entities/Asset/AssetHolders
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Checkpoints/Checkpoints.md
+++ b/sdk-docs/modules/API/Entities/Asset/Checkpoints/Checkpoints.md
@@ -1,10 +1,8 @@
 ---
 id: "Checkpoints"
-title: "Module: api/entities/Asset/Checkpoints"
+title: "Module: Checkpoints"
 sidebar_label: "Checkpoints"
 ---
-
-# Module: api/entities/Asset/Checkpoints
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Checkpoints/Schedules/Schedules.md
+++ b/sdk-docs/modules/API/Entities/Asset/Checkpoints/Schedules/Schedules.md
@@ -1,10 +1,8 @@
 ---
 id: "Schedules"
-title: "Module: api/entities/Asset/Checkpoints/Schedules"
+title: "Module: Schedules"
 sidebar_label: "Schedules"
 ---
-
-# Module: api/entities/Asset/Checkpoints/Schedules
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Checkpoints/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/Asset/Checkpoints/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/Asset/Checkpoints/types"
+title: "Module: Checkpoints Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/Asset/Checkpoints/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/API/Entities/Asset/Compliance/Compliance.md
+++ b/sdk-docs/modules/API/Entities/Asset/Compliance/Compliance.md
@@ -1,10 +1,8 @@
 ---
 id: "Compliance"
-title: "Module: api/entities/Asset/Compliance"
+title: "Module: Compliance"
 sidebar_label: "Compliance"
 ---
-
-# Module: api/entities/Asset/Compliance
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Compliance/Requirements/Requirements.md
+++ b/sdk-docs/modules/API/Entities/Asset/Compliance/Requirements/Requirements.md
@@ -1,10 +1,8 @@
 ---
 id: "Requirements"
-title: "Module: api/entities/Asset/Compliance/Requirements"
+title: "Module: Requirements"
 sidebar_label: "Requirements"
 ---
-
-# Module: api/entities/Asset/Compliance/Requirements
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Compliance/TrustedClaimIssuers/TrustedClaimIssuers.md
+++ b/sdk-docs/modules/API/Entities/Asset/Compliance/TrustedClaimIssuers/TrustedClaimIssuers.md
@@ -1,10 +1,8 @@
 ---
 id: "TrustedClaimIssuers"
-title: "Module: api/entities/Asset/Compliance/TrustedClaimIssuers"
+title: "Module: TrustedClaimIssuers"
 sidebar_label: "TrustedClaimIssuers"
 ---
-
-# Module: api/entities/Asset/Compliance/TrustedClaimIssuers
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/CorporateActions/CorporateActions.md
+++ b/sdk-docs/modules/API/Entities/Asset/CorporateActions/CorporateActions.md
@@ -1,10 +1,8 @@
 ---
 id: "CorporateActions"
-title: "Module: api/entities/Asset/CorporateActions"
+title: "Module: CorporateActions"
 sidebar_label: "CorporateActions"
 ---
-
-# Module: api/entities/Asset/CorporateActions
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/CorporateActions/Distributions/Distributions.md
+++ b/sdk-docs/modules/API/Entities/Asset/CorporateActions/Distributions/Distributions.md
@@ -1,10 +1,8 @@
 ---
 id: "Distributions"
-title: "Module: api/entities/Asset/CorporateActions/Distributions"
+title: "Module: Distributions"
 sidebar_label: "Distributions"
 ---
-
-# Module: api/entities/Asset/CorporateActions/Distributions
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/CorporateActions/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/Asset/CorporateActions/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/Asset/CorporateActions/types"
+title: "Module: CorporateActions Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/Asset/CorporateActions/types
 
 ## Interfaces
 

--- a/sdk-docs/modules/API/Entities/Asset/Documents/Documents.md
+++ b/sdk-docs/modules/API/Entities/Asset/Documents/Documents.md
@@ -1,10 +1,8 @@
 ---
 id: "Documents"
-title: "Module: api/entities/Asset/Documents"
+title: "Module: Documents"
 sidebar_label: "Documents"
 ---
-
-# Module: api/entities/Asset/Documents
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Issuance/Issuance.md
+++ b/sdk-docs/modules/API/Entities/Asset/Issuance/Issuance.md
@@ -1,10 +1,8 @@
 ---
 id: "Issuance"
-title: "Module: api/entities/Asset/Issuance"
+title: "Module: Issuance"
 sidebar_label: "Issuance"
 ---
-
-# Module: api/entities/Asset/Issuance
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Metadata/Metadata.md
+++ b/sdk-docs/modules/API/Entities/Asset/Metadata/Metadata.md
@@ -1,10 +1,8 @@
 ---
 id: "Metadata"
-title: "Module: api/entities/Asset/Metadata"
+title: "Module: Metadata"
 sidebar_label: "Metadata"
 ---
-
-# Module: api/entities/Asset/Metadata
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Offerings/Offerings.md
+++ b/sdk-docs/modules/API/Entities/Asset/Offerings/Offerings.md
@@ -1,10 +1,8 @@
 ---
 id: "Offerings"
-title: "Module: api/entities/Asset/Offerings"
+title: "Module: Offerings"
 sidebar_label: "Offerings"
 ---
-
-# Module: api/entities/Asset/Offerings
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Permissions/Permissions.md
+++ b/sdk-docs/modules/API/Entities/Asset/Permissions/Permissions.md
@@ -1,10 +1,8 @@
 ---
 id: "Permissions"
-title: "Module: api/entities/Asset/Permissions"
+title: "Module: Permissions"
 sidebar_label: "Permissions"
 ---
-
-# Module: api/entities/Asset/Permissions
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Settlements/Settlements.md
+++ b/sdk-docs/modules/API/Entities/Asset/Settlements/Settlements.md
@@ -1,10 +1,8 @@
 ---
 id: "Settlements"
-title: "Module: api/entities/Asset/Settlements"
+title: "Module: Settlements"
 sidebar_label: "Settlements"
 ---
-
-# Module: api/entities/Asset/Settlements
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/ClaimCount/ClaimCount.md
+++ b/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/ClaimCount/ClaimCount.md
@@ -1,10 +1,8 @@
 ---
 id: "ClaimCount"
-title: "Module: api/entities/Asset/TransferRestrictions/ClaimCount"
+title: "Module: ClaimCount"
 sidebar_label: "ClaimCount"
 ---
-
-# Module: api/entities/Asset/TransferRestrictions/ClaimCount
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/ClaimPercentage/ClaimPercentage.md
+++ b/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/ClaimPercentage/ClaimPercentage.md
@@ -1,10 +1,8 @@
 ---
 id: "ClaimPercentage"
-title: "Module: api/entities/Asset/TransferRestrictions/ClaimPercentage"
+title: "Module: ClaimPercentage"
 sidebar_label: "ClaimPercentage"
 ---
-
-# Module: api/entities/Asset/TransferRestrictions/ClaimPercentage
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/Count/Count.md
+++ b/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/Count/Count.md
@@ -1,10 +1,8 @@
 ---
 id: "Count"
-title: "Module: api/entities/Asset/TransferRestrictions/Count"
+title: "Module: Count"
 sidebar_label: "Count"
 ---
-
-# Module: api/entities/Asset/TransferRestrictions/Count
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/Percentage/Percentage.md
+++ b/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/Percentage/Percentage.md
@@ -1,10 +1,8 @@
 ---
 id: "Percentage"
-title: "Module: api/entities/Asset/TransferRestrictions/Percentage"
+title: "Module: Percentage"
 sidebar_label: "Percentage"
 ---
-
-# Module: api/entities/Asset/TransferRestrictions/Percentage
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/TransferRestrictionBase/TransferRestrictionBase.md
+++ b/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/TransferRestrictionBase/TransferRestrictionBase.md
@@ -1,10 +1,8 @@
 ---
 id: "TransferRestrictionBase"
-title: "Module: api/entities/Asset/TransferRestrictions/TransferRestrictionBase"
+title: "Module: TransferRestrictionBase"
 sidebar_label: "TransferRestrictionBase"
 ---
-
-# Module: api/entities/Asset/TransferRestrictions/TransferRestrictionBase
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/TransferRestrictions.md
+++ b/sdk-docs/modules/API/Entities/Asset/TransferRestrictions/TransferRestrictions.md
@@ -1,10 +1,8 @@
 ---
 id: "TransferRestrictions"
-title: "Module: api/entities/Asset/TransferRestrictions"
+title: "Module: TransferRestrictions"
 sidebar_label: "TransferRestrictions"
 ---
-
-# Module: api/entities/Asset/TransferRestrictions
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Asset/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/Asset/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/Asset/types"
+title: "Module: Asset Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/Asset/types
 
 ## Interfaces
 

--- a/sdk-docs/modules/API/Entities/AuthorizationRequest/AuthorizationRequest.md
+++ b/sdk-docs/modules/API/Entities/AuthorizationRequest/AuthorizationRequest.md
@@ -1,10 +1,8 @@
 ---
 id: "AuthorizationRequest"
-title: "Module: api/entities/AuthorizationRequest"
+title: "Module: AuthorizationRequest"
 sidebar_label: "AuthorizationRequest"
 ---
-
-# Module: api/entities/AuthorizationRequest
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Checkpoint/Checkpoint.md
+++ b/sdk-docs/modules/API/Entities/Checkpoint/Checkpoint.md
@@ -1,10 +1,8 @@
 ---
 id: "Checkpoint"
-title: "Module: api/entities/Checkpoint"
+title: "Module: Checkpoint"
 sidebar_label: "Checkpoint"
 ---
-
-# Module: api/entities/Checkpoint
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/CheckpointSchedule/CheckpointSchedule.md
+++ b/sdk-docs/modules/API/Entities/CheckpointSchedule/CheckpointSchedule.md
@@ -1,10 +1,8 @@
 ---
 id: "CheckpointSchedule"
-title: "Module: api/entities/CheckpointSchedule"
+title: "Module: CheckpointSchedule"
 sidebar_label: "CheckpointSchedule"
 ---
-
-# Module: api/entities/CheckpointSchedule
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/CheckpointSchedule/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/CheckpointSchedule/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/CheckpointSchedule/types"
+title: "Module: CheckpointSchedule Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/CheckpointSchedule/types
 
 ## Interfaces
 

--- a/sdk-docs/modules/API/Entities/Common/Namespaces/Authorizations/Authorizations.md
+++ b/sdk-docs/modules/API/Entities/Common/Namespaces/Authorizations/Authorizations.md
@@ -1,10 +1,8 @@
 ---
 id: "Authorizations"
-title: "Module: api/entities/common/namespaces/Authorizations"
+title: "Module: Authorizations"
 sidebar_label: "Authorizations"
 ---
-
-# Module: api/entities/common/namespaces/Authorizations
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/CorporateAction/CorporateAction.md
+++ b/sdk-docs/modules/API/Entities/CorporateAction/CorporateAction.md
@@ -1,10 +1,8 @@
 ---
 id: "CorporateAction"
-title: "Module: api/entities/CorporateAction"
+title: "Module: CorporateAction"
 sidebar_label: "CorporateAction"
 ---
-
-# Module: api/entities/CorporateAction
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/CorporateActionBase/CorporateActionBase.md
+++ b/sdk-docs/modules/API/Entities/CorporateActionBase/CorporateActionBase.md
@@ -1,10 +1,8 @@
 ---
 id: "CorporateActionBase"
-title: "Module: api/entities/CorporateActionBase"
+title: "Module: CorporateActionBase"
 sidebar_label: "CorporateActionBase"
 ---
-
-# Module: api/entities/CorporateActionBase
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/CorporateActionBase/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/CorporateActionBase/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/CorporateActionBase/types"
+title: "Module: CorporateActionBase Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/CorporateActionBase/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/API/Entities/CustomPermissionGroup/CustomPermissionGroup.md
+++ b/sdk-docs/modules/API/Entities/CustomPermissionGroup/CustomPermissionGroup.md
@@ -1,10 +1,8 @@
 ---
 id: "CustomPermissionGroup"
-title: "Module: api/entities/CustomPermissionGroup"
+title: "Module: CustomPermissionGroup"
 sidebar_label: "CustomPermissionGroup"
 ---
-
-# Module: api/entities/CustomPermissionGroup
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/DefaultPortfolio/DefaultPortfolio.md
+++ b/sdk-docs/modules/API/Entities/DefaultPortfolio/DefaultPortfolio.md
@@ -1,10 +1,8 @@
 ---
 id: "DefaultPortfolio"
-title: "Module: api/entities/DefaultPortfolio"
+title: "Module: DefaultPortfolio"
 sidebar_label: "DefaultPortfolio"
 ---
-
-# Module: api/entities/DefaultPortfolio
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/DefaultTrustedClaimIssuer/DefaultTrustedClaimIssuer.md
+++ b/sdk-docs/modules/API/Entities/DefaultTrustedClaimIssuer/DefaultTrustedClaimIssuer.md
@@ -1,10 +1,8 @@
 ---
 id: "DefaultTrustedClaimIssuer"
-title: "Module: api/entities/DefaultTrustedClaimIssuer"
+title: "Module: DefaultTrustedClaimIssuer"
 sidebar_label: "DefaultTrustedClaimIssuer"
 ---
-
-# Module: api/entities/DefaultTrustedClaimIssuer
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/DividendDistribution/DividendDistribution.md
+++ b/sdk-docs/modules/API/Entities/DividendDistribution/DividendDistribution.md
@@ -1,10 +1,8 @@
 ---
 id: "DividendDistribution"
-title: "Module: api/entities/DividendDistribution"
+title: "Module: DividendDistribution"
 sidebar_label: "DividendDistribution"
 ---
-
-# Module: api/entities/DividendDistribution
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/DividendDistribution/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/DividendDistribution/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/DividendDistribution/types"
+title: "Module: DividendDistribution Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/DividendDistribution/types
 
 ## Interfaces
 

--- a/sdk-docs/modules/API/Entities/Entity/Entity.md
+++ b/sdk-docs/modules/API/Entities/Entity/Entity.md
@@ -1,10 +1,8 @@
 ---
 id: "Entity"
-title: "Module: api/entities/Entity"
+title: "Module: Entity"
 sidebar_label: "Entity"
 ---
-
-# Module: api/entities/Entity
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Identity/AssetPermissions/AssetPermissions.md
+++ b/sdk-docs/modules/API/Entities/Identity/AssetPermissions/AssetPermissions.md
@@ -1,10 +1,8 @@
 ---
 id: "AssetPermissions"
-title: "Module: api/entities/Identity/AssetPermissions"
+title: "Module: AssetPermissions"
 sidebar_label: "AssetPermissions"
 ---
-
-# Module: api/entities/Identity/AssetPermissions
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Identity/Identity.md
+++ b/sdk-docs/modules/API/Entities/Identity/Identity.md
@@ -1,10 +1,8 @@
 ---
 id: "Identity"
-title: "Module: api/entities/Identity"
+title: "Module: Identity"
 sidebar_label: "Identity"
 ---
-
-# Module: api/entities/Identity
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Identity/IdentityAuthorizations/IdentityAuthorizations.md
+++ b/sdk-docs/modules/API/Entities/Identity/IdentityAuthorizations/IdentityAuthorizations.md
@@ -1,10 +1,8 @@
 ---
 id: "IdentityAuthorizations"
-title: "Module: api/entities/Identity/IdentityAuthorizations"
+title: "Module: IdentityAuthorizations"
 sidebar_label: "IdentityAuthorizations"
 ---
-
-# Module: api/entities/Identity/IdentityAuthorizations
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Identity/Portfolios/Portfolios.md
+++ b/sdk-docs/modules/API/Entities/Identity/Portfolios/Portfolios.md
@@ -1,10 +1,8 @@
 ---
 id: "Portfolios"
-title: "Module: api/entities/Identity/Portfolios"
+title: "Module: Portfolios"
 sidebar_label: "Portfolios"
 ---
-
-# Module: api/entities/Identity/Portfolios
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Instruction/Instruction.md
+++ b/sdk-docs/modules/API/Entities/Instruction/Instruction.md
@@ -1,10 +1,8 @@
 ---
 id: "Instruction"
-title: "Module: api/entities/Instruction"
+title: "Module: Instruction"
 sidebar_label: "Instruction"
 ---
-
-# Module: api/entities/Instruction
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Instruction/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/Instruction/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/Instruction/types"
+title: "Module: Instruction Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/Instruction/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/API/Entities/KnownPermissionGroup/KnownPermissionGroup.md
+++ b/sdk-docs/modules/API/Entities/KnownPermissionGroup/KnownPermissionGroup.md
@@ -1,10 +1,8 @@
 ---
 id: "KnownPermissionGroup"
-title: "Module: api/entities/KnownPermissionGroup"
+title: "Module: KnownPermissionGroup"
 sidebar_label: "KnownPermissionGroup"
 ---
-
-# Module: api/entities/KnownPermissionGroup
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/MetadataEntry/MetadataEntry.md
+++ b/sdk-docs/modules/API/Entities/MetadataEntry/MetadataEntry.md
@@ -1,10 +1,8 @@
 ---
 id: "MetadataEntry"
-title: "Module: api/entities/MetadataEntry"
+title: "Module: MetadataEntry"
 sidebar_label: "MetadataEntry"
 ---
-
-# Module: api/entities/MetadataEntry
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/MetadataEntry/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/MetadataEntry/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/MetadataEntry/types"
+title: "Module: MetadataEntry Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/MetadataEntry/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/API/Entities/MultiSig/MultiSig.md
+++ b/sdk-docs/modules/API/Entities/MultiSig/MultiSig.md
@@ -1,10 +1,8 @@
 ---
 id: "MultiSig"
-title: "Module: api/entities/MultiSig"
+title: "Module: MultiSig"
 sidebar_label: "MultiSig"
 ---
-
-# Module: api/entities/MultiSig
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/MultiSig/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/MultiSig/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/MultiSig/types"
+title: "Module: MultiSig Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/MultiSig/types
 
 ## Interfaces
 

--- a/sdk-docs/modules/API/Entities/MultiSigProposal/MultiSigProposal.md
+++ b/sdk-docs/modules/API/Entities/MultiSigProposal/MultiSigProposal.md
@@ -1,10 +1,8 @@
 ---
 id: "MultiSigProposal"
-title: "Module: api/entities/MultiSigProposal"
+title: "Module: MultiSigProposal"
 sidebar_label: "MultiSigProposal"
 ---
-
-# Module: api/entities/MultiSigProposal
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/MultiSigProposal/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/MultiSigProposal/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/MultiSigProposal/types"
+title: "Module: MultiSigProposal Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/MultiSigProposal/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/API/Entities/NumberedPortfolio/NumberedPortfolio.md
+++ b/sdk-docs/modules/API/Entities/NumberedPortfolio/NumberedPortfolio.md
@@ -1,10 +1,8 @@
 ---
 id: "NumberedPortfolio"
-title: "Module: api/entities/NumberedPortfolio"
+title: "Module: NumberedPortfolio"
 sidebar_label: "NumberedPortfolio"
 ---
-
-# Module: api/entities/NumberedPortfolio
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Offering/Offering.md
+++ b/sdk-docs/modules/API/Entities/Offering/Offering.md
@@ -1,10 +1,8 @@
 ---
 id: "Offering"
-title: "Module: api/entities/Offering"
+title: "Module: Offering"
 sidebar_label: "Offering"
 ---
-
-# Module: api/entities/Offering
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Offering/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/Offering/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/Offering/types"
+title: "Module: Offering Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/Offering/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/API/Entities/PermissionGroup/PermissionGroup.md
+++ b/sdk-docs/modules/API/Entities/PermissionGroup/PermissionGroup.md
@@ -1,10 +1,8 @@
 ---
 id: "PermissionGroup"
-title: "Module: api/entities/PermissionGroup"
+title: "Module: PermissionGroup"
 sidebar_label: "PermissionGroup"
 ---
-
-# Module: api/entities/PermissionGroup
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Portfolio/Portfolio.md
+++ b/sdk-docs/modules/API/Entities/Portfolio/Portfolio.md
@@ -1,10 +1,8 @@
 ---
 id: "Portfolio"
-title: "Module: api/entities/Portfolio"
+title: "Module: Portfolio"
 sidebar_label: "Portfolio"
 ---
-
-# Module: api/entities/Portfolio
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Portfolio/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/Portfolio/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/Portfolio/types"
+title: "Module: Portfolio Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/Portfolio/types
 
 ## Interfaces
 

--- a/sdk-docs/modules/API/Entities/Subsidies/Subsidies.md
+++ b/sdk-docs/modules/API/Entities/Subsidies/Subsidies.md
@@ -1,10 +1,8 @@
 ---
 id: "Subsidies"
-title: "Module: api/entities/Subsidies"
+title: "Module: Subsidies"
 sidebar_label: "Subsidies"
 ---
-
-# Module: api/entities/Subsidies
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Subsidy/Subsidy.md
+++ b/sdk-docs/modules/API/Entities/Subsidy/Subsidy.md
@@ -1,10 +1,8 @@
 ---
 id: "Subsidy"
-title: "Module: api/entities/Subsidy"
+title: "Module: Subsidy"
 sidebar_label: "Subsidy"
 ---
-
-# Module: api/entities/Subsidy
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/Subsidy/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/Subsidy/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/Subsidy/types"
+title: "Module: Subsidy Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/Subsidy/types
 
 ## Interfaces
 

--- a/sdk-docs/modules/API/Entities/TickerReservation/TickerReservation.md
+++ b/sdk-docs/modules/API/Entities/TickerReservation/TickerReservation.md
@@ -1,10 +1,8 @@
 ---
 id: "TickerReservation"
-title: "Module: api/entities/TickerReservation"
+title: "Module: TickerReservation"
 sidebar_label: "TickerReservation"
 ---
-
-# Module: api/entities/TickerReservation
 
 ## Classes
 

--- a/sdk-docs/modules/API/Entities/TickerReservation/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/TickerReservation/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/TickerReservation/types"
+title: "Module: TickerReservation Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/TickerReservation/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/API/Entities/Venue/Types/Types.md
+++ b/sdk-docs/modules/API/Entities/Venue/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/entities/Venue/types"
+title: "Module: Venue Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/entities/Venue/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/API/Entities/Venue/Venue.md
+++ b/sdk-docs/modules/API/Entities/Venue/Venue.md
@@ -1,10 +1,8 @@
 ---
 id: "Venue"
-title: "Module: api/entities/Venue"
+title: "Module: Venue"
 sidebar_label: "Venue"
 ---
-
-# Module: api/entities/Venue
 
 ## Classes
 

--- a/sdk-docs/modules/API/Procedures/Types/Types.md
+++ b/sdk-docs/modules/API/Procedures/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: api/procedures/types"
+title: "Module: Procedures Types"
 sidebar_label: "Types"
 ---
-
-# Module: api/procedures/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/Base/PolymeshError/PolymeshError.md
+++ b/sdk-docs/modules/Base/PolymeshError/PolymeshError.md
@@ -1,10 +1,8 @@
 ---
 id: "PolymeshError"
-title: "Module: base/PolymeshError"
+title: "Module: PolymeshError"
 sidebar_label: "PolymeshError"
 ---
-
-# Module: base/PolymeshError
 
 ## Classes
 

--- a/sdk-docs/modules/Base/PolymeshTransaction/PolymeshTransaction.md
+++ b/sdk-docs/modules/Base/PolymeshTransaction/PolymeshTransaction.md
@@ -1,10 +1,8 @@
 ---
 id: "PolymeshTransaction"
-title: "Module: base/PolymeshTransaction"
+title: "Module: PolymeshTransaction"
 sidebar_label: "PolymeshTransaction"
 ---
-
-# Module: base/PolymeshTransaction
 
 ## Classes
 

--- a/sdk-docs/modules/Base/PolymeshTransactionBase/PolymeshTransactionBase.md
+++ b/sdk-docs/modules/Base/PolymeshTransactionBase/PolymeshTransactionBase.md
@@ -1,10 +1,8 @@
 ---
 id: "PolymeshTransactionBase"
-title: "Module: base/PolymeshTransactionBase"
+title: "Module: PolymeshTransactionBase"
 sidebar_label: "PolymeshTransactionBase"
 ---
-
-# Module: base/PolymeshTransactionBase
 
 ## Classes
 

--- a/sdk-docs/modules/Base/PolymeshTransactionBatch/PolymeshTransactionBatch.md
+++ b/sdk-docs/modules/Base/PolymeshTransactionBatch/PolymeshTransactionBatch.md
@@ -1,10 +1,8 @@
 ---
 id: "PolymeshTransactionBatch"
-title: "Module: base/PolymeshTransactionBatch"
+title: "Module: PolymeshTransactionBatch"
 sidebar_label: "PolymeshTransactionBatch"
 ---
-
-# Module: base/PolymeshTransactionBatch
 
 ## Classes
 

--- a/sdk-docs/modules/Base/Types/Types.md
+++ b/sdk-docs/modules/Base/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: base/types"
+title: "Module: Base Types"
 sidebar_label: "Types"
 ---
-
-# Module: base/types
 
 ## Type Aliases
 

--- a/sdk-docs/modules/Generated/Types/Types.md
+++ b/sdk-docs/modules/Generated/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: generated/types"
+title: "Module: Generated Types"
 sidebar_label: "Types"
 ---
-
-# Module: generated/types
 
 ## Enumerations
 

--- a/sdk-docs/modules/Types/Types.md
+++ b/sdk-docs/modules/Types/Types.md
@@ -1,10 +1,8 @@
 ---
 id: "Types"
-title: "Module: types"
+title: "Module: Types"
 sidebar_label: "Types"
 ---
-
-# Module: types
 
 ## Enumerations
 

--- a/sdk-docs/modules/Types/Utils/Utils.md
+++ b/sdk-docs/modules/Types/Utils/Utils.md
@@ -1,10 +1,8 @@
 ---
 id: "Utils"
-title: "Module: types/utils"
+title: "Module: utils"
 sidebar_label: "Utils"
 ---
-
-# Module: types/utils
 
 ## Type Aliases
 


### PR DESCRIPTION
Remove generated index pages as they were lowering search rankings in comparison to SDK results

Remove path parts from titles of module pages to improve search result relevance.