### PR TITLE
Heap exhaustion workaround

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           sed -i 's#baseUrl: '\''/'\''#baseUrl: '\''/polymesh-documentation-site/'\''#' docusaurus.config.js
 
       - name: Build website
-        run: export NODE_OPTIONS="--max_old_space_size=8192" && yarn build
+        run: yarn build
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Test build website
-        run: export NODE_OPTIONS="--max_old_space_size=8192" && yarn build
+        run: yarn build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "export NODE_OPTIONS=\"--max_old_space_size=4096\" && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "export NODE_OPTIONS=\"--max_old_space_size=4096\" && docusaurus build",
+    "build": "export NODE_OPTIONS=\"--max-old-space-size=4096\" && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
 Enables the build process to consume up to 4GB of heap space; workaround for `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` errors being thrown as a result of resource overutilization due to the project's dependencies.

V8's unmodified heap size limit is `size_t max_old_generation_size = 700ul * (kSystemPointerSize / 4) * MB;` (ie. `700 * (8 / 4) = 1400MB` x64 || `700 * (4 / 4) = 700MB` x86); `docusaurus build` consumes a *significant* amount of memory while transpiling/minifying/etc, exceeding this limit and causing the process to terminate with `SIGABRT` (ie. Abnormal Termination).