### PR TITLE
fix: add python3 and build tools for native module compilation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM node:lts-alpine AS builder
 ################################################################
 
 WORKDIR /home/node
-RUN corepack enable
+RUN apk add --no-cache python3 make g++ && corepack enable
 USER node
 
 ################################################################


### PR DESCRIPTION
Install python3, make, and g++ in Docker builder stage to support node-gyp compilation of native modules like utf-8-validate.