### PR TITLE
Add v7.4 account based asset transfers documentation

### DIFF
--- a/docs/200-core-concepts/030-identity/040-advanced/050-subsidized.md
+++ b/docs/200-core-concepts/030-identity/040-advanced/050-subsidized.md
@@ -53,7 +53,7 @@ Before implementing subsidized accounts, be aware of these important limitations
 
 1. **Account Restrictions**:
    - When an account has an active subsidy, it cannot submit non-subsidized transactions
-   - Only specific transactions, defined in the chain runtime are eligible for subsidization. AAll transaction related to Asset and Identity management are supported.
+   - Only specific transactions, defined in the chain runtime are eligible for subsidization. All transactions related to Asset and Identity management are supported.
    - This restriction helps prevent fee circumvention and ensures proper subsidy tracking
 
 2. **Batch Transaction Restrictions**:

--- a/docs/200-core-concepts/030-identity/040-advanced/050-subsidized.md
+++ b/docs/200-core-concepts/030-identity/040-advanced/050-subsidized.md
@@ -52,18 +52,15 @@ Subsidies are established at the account level. All transactions from the subsid
 Before implementing subsidized accounts, be aware of these important limitations:
 
 1. **Account Restrictions**:
-
    - When an account has an active subsidy, it cannot submit non-subsidized transactions
-   - Only specific transactions, defined in the chain runtime are eligible for subsidization. All transaction related to Asset and Identity management are supported.
+   - Only specific transactions, defined in the chain runtime are eligible for subsidization. AAll transaction related to Asset and Identity management are supported.
    - This restriction helps prevent fee circumvention and ensures proper subsidy tracking
 
 2. **Batch Transaction Restrictions**:
-
    - When using subsidies, batch transactions are limited to a maximum of 7 transactions
    - Nested batch calls are not supported when using subsidies
 
 3. **Allowance Management**:
-
    - Subsidies have a maximum allowance that cannot be exceeded
    - Once an allowance is exhausted, it must be renewed by the subsidizer before the key can transact again
 

--- a/docs/200-core-concepts/030-identity/index.mdx
+++ b/docs/200-core-concepts/030-identity/index.mdx
@@ -17,7 +17,8 @@ Each identity:
 
 - Is created through a [Customer Due Diligence (CDD) process](/identity/verification)
 - Is referenced by a pseudo-anonymous decentralized identifier (DID), e.g., `0xfc0d2fc058d02c0a89c2cc2ff11726971dd39886a0b80ecfaa80fa3f196d65ce`
-- Can hold [assets](/core/assets) in associated [portfolios](/portfolios), [claims](/compliance/#claims), and [permissioned roles](/identity/roles)
+- Can hold [asset](/core/assets) balances in associated [portfolios](/portfolios) or Account IDs (signing key public addresses) connected to the identity.
+- Can be associated with [claims](/compliance/#claims) and have [permissioned roles](/identity/roles)
 - Is controlled by a [primary key](/identity/advanced/primary-keys) and optional [secondary keys](/identity/advanced/secondary-keys)
 
 ## Identity Requirement on Polymesh
@@ -42,7 +43,7 @@ Identities are created through [permissioned CDD service providers](/identity/ve
 
 ### Asset Management
 
-Native [assets](/core/assets) (excluding [POLYX](/polyx)) held by users are associated with their identities and can be organized into [portfolios](/portfolios). Each identity can hold multiple assets and manage them through different portfolios. Identities may also be granted [agent permissions](/asset-agents) to perform specific operations on behalf of asset issuers.
+Native [assets](/core/assets) (excluding [POLYX](/polyx)) held by users are associated with their on-chain identity. Assets can be organized into [portfolios](/portfolios). From version `7.4.0` of the Polymesh runtime, signing key's public account IDs can also hold a balance for native assets (`PortfolioKind::AccountId`) provided they are associated with an identity as either a [primary key](/identity/advanced/primary-keys) or [secondary key](/identity/advanced/secondary-keys). Each identity can hold multiple assets and manage them through different portfolios. Identities may also be granted [agent permissions](/asset-agents) to perform specific operations on behalf of asset issuers.
 
 ### Claims & Compliance
 

--- a/docs/200-core-concepts/040-assets/010-fungible.md
+++ b/docs/200-core-concepts/040-assets/010-fungible.md
@@ -29,14 +29,14 @@ To create a fungible asset, users specify the asset type (e.g., Equity, Bond, Fu
 
 ## Issuance and Distribution
 
-After creation, issuers or their appointed [agents](/asset-agents) can issue tokens to portfolios they control. Tokens can then be distributed to investors through a security token offering or directly using the settlement and compliance engines. See [Settlement](/settlement) and [Security Token Offerings](/sto) for more on fundraising and distribution.
+After creation, issuers or their appointed [agents](/asset-agents) can issue tokens to portfolios or accounts associated with their identity. Tokens can then be distributed to investors through a security token offering or directly using the settlement and compliance engines. See [Settlement](/settlement) and [Security Token Offerings](/sto) for more on fundraising and distribution.
 
 ## Key Features Unique to Fungible Assets
 
 ### Issuance and Redemption
 
-- **Issuance**: An agent of the fungible asset can mint (issue) tokens to a portfolio under their on-chain identity (control of the portfolio can be assigned to another identity before issuing assets). This increases the total supply and the recipient's balance. Tokens are issued by calling the `asset::issue` method, specifying the `asset_id`, `amount`, and target portfolio.
-- **Redemption**: Tokens can be redeemed (burned) from a portfolio owned by an appropriately permissioned agent of the asset, reducing both the total supply and the portfolio's balance. Tokens are redeemed by calling the `asset::redeem` method, specifying the `asset_id`, `value`, and portfolio to redeem the tokens from.
+- **Issuance**: An agent of the fungible asset can mint (issue) tokens to a portfolio or account under their on-chain identity (control of a portfolio can be assigned to another identity before issuing assets). This increases the total supply and the agents balance. Tokens are issued by calling the `asset::issue` method, specifying the `asset_id`, `amount`, and target portfolio or account.
+- **Redemption**: Tokens can be redeemed (burned) from a portfolio or account owned by an appropriately permissioned agent of the asset, reducing both the total supply and the portfolio or account's balance. Tokens are redeemed by calling the `asset::redeem` method, specifying the `asset_id`, `value`, and portfolio or account to redeem the tokens from.
 
 ### Divisibility
 

--- a/docs/200-core-concepts/040-assets/080-ownership-transfer.md
+++ b/docs/200-core-concepts/040-assets/080-ownership-transfer.md
@@ -25,9 +25,9 @@ If there is a **Ticker** linked to an asset, the ownership of that ticker will a
 :::
 
 :::warning Important Warning
-**Transferring asset ownership does NOT automatically add the new owner as an asset agent or remove existing asset agents.**
+**Transferring asset ownership updates agent assignments automatically.** The previous owner is removed as an agent and the new owner is added as a `Full` agent when the transfer completes. Other agents and their permissions are unchanged.
 
-Asset agents are managed independently of ownership. As part of the asset transfer, the previous owner should make the new owner a full agent of the asset. After a transfer, the new owner should review and update the list of asset agents and their permissions to ensure only trusted parties retain access. Failing to do so may leave previous agents with unintended control over the asset.
+After a transfer, the new owner should review and update the list of asset agents and their permissions to ensure only trusted parties retain access.
 
 See [Asset Agents & Permissions](/asset-agents) for more information.
 :::

--- a/docs/200-core-concepts/040-assets/090-agents.md
+++ b/docs/200-core-concepts/040-assets/090-agents.md
@@ -141,7 +141,7 @@ When an Identity creates an asset, that Identity is automatically assigned to th
 ## Ownership Transfer Considerations
 
 :::warning Critical Note
-Agent permissions are tied to the asset, not the asset owner's Identity. When asset ownership (control) is transferred to a new Identity, the previous owner retains their agent permissions unless explicitly removed. Managing agent permissions is a key step during ownership changes. The new owner must first be added as an agent (typically to the `Full` group) before the previous owner can be removed or have their permissions reduced.
+Agent permissions are tied to the asset, not the asset owner's Identity. When asset ownership (control) is transferred to a new Identity, the previous owner is removed as an agent and the new owner is added as a `Full` agent automatically. Other agents and their permissions remain unchanged, so managing agent permissions is still a key step during ownership changes.
 :::
 
 ## SDK Integration

--- a/docs/200-core-concepts/060-settlement/index.mdx
+++ b/docs/200-core-concepts/060-settlement/index.mdx
@@ -11,14 +11,14 @@ tags:
 
 ## Overview
 
-Settlement in Polymesh is the process by which assets are transferred between identities in a regulated and compliant fashion. It requires all counterparties to affirm (agree) an instruction (a set of asset transfers) before the instruction settles (completes).
+Settlement in Polymesh is the process by which assets are transferred between identities in a regulated and compliant fashion. Asset balances can be held in portfolios under an identity or signing accounts (public key address) linked to an identity. It requires all counterparties to affirm (agree) an instruction (a set of asset transfers) before the instruction settles (completes).
 
 Key characteristics of Polymesh settlement:
 
 - **Multi-party coordination**: All counterparties must explicitly authorize transfers
 - **Double spending prevention**: Assets are locked upon sender affirmation
 - **Flexible execution**: Multiple settlement types accommodate different workflow requirements
-- **Unilateral rejection**: Any counterparty can reject an instruction at any time
+- **Unilateral rejection**: Any counterparty can reject an instruction at any time prior to execution
 - **Optional mediation**: Third-party validation through [settlement mediators](/settlement/mediators) (e.g. a transfer agent)
 
 ## Settlement Types
@@ -45,14 +45,14 @@ These date fields are purely informational metadata and are **not enforced** by 
 
 Instructions can settle via:
 
-- **On-chain movement**: Direct transfer of on-chain assets between portfolios
+- **On-chain movement**: Direct transfer of on-chain assets between any combination of portfolios and Account IDs.
 - **Off-chain payment receipts**: Signed attestations that off-chain asset transfers occurred. See [Off-Chain Settlement](/settlement/off-chain/) for details.
 
 ## Double Spending Prevention
 
 Polymesh prevents double spending through immediate asset locking:
 
-- When a sender affirms an instruction, required assets are immediately locked in their portfolio
+- When a sender affirms an instruction, required assets are immediately locked (whether held in a portfolio or at an Account ID)
 - Locked assets cannot be used in other transactions until released
 - Asset locks are only released when:
   - The instruction is successfully executed (assets are transferred)
@@ -166,21 +166,21 @@ Each leg within an instruction specifies:
 - **Asset**: The specific asset to be transferred (identified by Asset ID)
 - **Amount**: The quantity of the asset to transfer (for fungible assets)
 - **NFTs**: The specific NFT IDs to transfer (for non-fungible assets, up to 10 NFTs per leg)
-- **Sender portfolio**: The portfolio from which assets will be transferred
-- **Receiver portfolio**: The portfolio that will receive the assets
+- **Sender**: The portfolio or Account ID from which assets will be transferred
+- **Receiver**: The portfolio or Account ID that will receive the assets
 - **Leg type**: On-chain transfer or off-chain receipt
 
 ### Leg Types
 
 **Fungible legs**:
 
-- Transfer a specific quantity of fungible tokens between portfolios
+- Transfer a specific quantity of fungible tokens between any combination of portfolios and Account IDs
 - Assets are locked when the sender affirms and transferred upon execution
 - Most common type for security tokens and other divisible assets
 
 **Non-fungible legs**:
 
-- Transfer specific NFT IDs from a single collection between portfolios
+- Transfer specific NFT IDs from a single collection between any combination of portfolios and Account IDs
 - Can transfer up to 10 individual NFTs per leg from the same collection
 - Each NFT is identified by its unique NFT ID within the collection
 - Assets are locked when the sender affirms and transferred upon execution
@@ -221,6 +221,56 @@ Instructions progress through several status states:
 2. **Affirmation**: Counterparties (and mediators if required) affirm the instruction (assets locked for senders). Where [portfolio custody](/portfolios/custody/) has been assigned, the controller of that portfolio is responsible for affirmation rather than the portfolio owner.
 3. **Execution**: Instruction settles based on its settlement type
 4. **Completion**: Assets transferred and instruction marked as successful
+
+## Portfolio and Account ID Transfer Path
+
+With v7.4.0, settlement enables transfers between portfolios and Account IDs (signing key balances) in both directions. This represents a shift from the previous Portfolio only and aligns with traditional key based balance models of other chains while still leveraging the settlement engine for compliance and regulatory requirements. The settlement engine handles all transfers between portfolios and Account IDs, ensuring consistent compliance checks, double-spend prevention, and regulatory controls regardless of the transfer path.
+
+Account ID balances were introduced as a non breaking change in v7.4.0 by extending the `PortfolioKind` type to support a type of `AccountId`. Settlement instructions still require the sender and receiver's DIDs to be looked up and provided as part of the instruction creation step when using the settlement pallet.
+
+Future chain updates may simplify the settlement instruction creation process by allowing the chain to automatically resolve the sender and receiver DIDs from their Account IDs, eliminating the need for clients to pre-resolve and provide this information while leveraging the full capabilities of the multi leg settlement engine.
+
+## Account ID Transfers (`transfer_asset`)
+
+Polymesh v7.4 introduces `asset::transfer_asset`, a simplified single-leg fungible asset transfer API that accepts a receiver's Account ID directly, eliminating the need for clients to pre-resolve the receiver's DID. The chain resolves the receiver's DID internally via on-chain identity lookup for compliance checks. This creates a streamlined Account ID to Account ID transfer model while still leveraging the settlement engine under the hood.
+
+:::info
+
+The `asset::transfer_asset` function is designed for simple single-leg transfers between Account IDs. If a sender only holds an asset in a [Portfolio](/portfolios/) they must first [move](/portfolios/#moving-funds-between-portfolios) the asset to their Account ID using `portfolio::move_portfolio_funds` before calling `asset::transfer_asset`.
+
+:::
+
+### How Account ID Transfers Work
+
+Account ID transfers work with balances held directly at the signing key's Account ID (using `PortfolioKind::AccountId` rather than explicit portfolios):
+
+1. **Sender initiates transfer**: Sender calls `transfer_asset` with:
+   - Receiver's Account ID (public address)
+   - Asset ID
+   - Amount
+   - Optional memo
+
+2. **On-chain DID resolution**: The chain automatically resolves the sender and receiver's DID from their Account IDs for compliance checks, removing any client-side lookups
+
+3. **Instruction creation**: A settlement [instruction](#instruction-structure) is created with a single leg:
+   - From: Sender's Account ID
+   - To: Receiver's Account ID
+   - Asset: The specified asset ID
+   - Amount: The transfer quantity
+
+4. **Sender affirmation**: The sending account is automatically [affirmed](#affirmation-requirements) and assets are locked
+
+5. **Settlement happens based on receiver status**:
+   - **If receiver [pre-approved](#asset-exemptions-and-pre-affirmation) the asset**: Instruction executes immediately in the same block without pending affirmation.
+   - **If receiver has NOT pre-approved**: Instruction created with a pending status and requires the receiver to call `asset::receiver_affirm_asset_transfer` or affirm via the settlement engine. This call also automatically resolves the receiver's DID and attempts instruction execution in the same block.
+   - Receiver can alternatively reject with `asset::reject_asset_transfer`
+
+### Key Characteristics
+
+- **Single-leg only**: Account ID transfers cannot have multiple legs (no multi-leg atomicity)
+- **No explicit portfolio support**: Transfers work directly with the signing key's Account ID balance
+- **Auto-execution on receiver approval**: When receiver affirms, execution happens atomically in the same transaction - no scheduler delay, immediate feedback on success or failure.
+- **Same engine**: Despite simplified API, uses the full settlement engine for compliance checks, double-spend prevention, and regulatory requirements
 
 ## Execution Behavior
 

--- a/docs/200-core-concepts/060-settlement/settlement-diagrams.mdx
+++ b/docs/200-core-concepts/060-settlement/settlement-diagrams.mdx
@@ -13,6 +13,10 @@ It's important to note that these diagrams offer a low-level representation, inc
 
 When using tools such as the Polymesh REST API or the Polymesh TypeScript SDK, some of the steps depicted in these diagrams are combined into a single user action. These tools can simplify the process for integrators, streamlining the integration of Assets.
 
+:::note
+These diagrams cover settlement flows for both traditional portfolio-based transfers and Account ID-based transfers (introduced in v7.4.0). The mechanics are the same regardless of whether senders and receivers hold assets in portfolios or at Account IDs.
+:::
+
 ## Asset Creation
 
 In this sequence diagram, the asset issuer creates, configures, and issues an asset. In this flow, the issuer performs these actions directly, but it is also possible to delegate the configuration and issuance steps to an agent once the asset has been created.
@@ -208,4 +212,50 @@ end
 I ->> P: Execute Settlement Instruction
 Note over I,P: Fully affirmed instructions can optionally be executed by any party to the instruction
 P ->> P: Sender and Receiver Balances<br>Updated and Lock Removed
+```
+
+## Simplified Account ID Transfer (`transfer_asset`)
+
+Starting with v7.4.0, Polymesh provides a simplified API (`asset::transfer_asset`) for single-leg fungible asset transfers between Account IDs. This flow is much simpler than the multi-leg settlement instruction process because it auto-affirms the sender and automatically executes when the receiver affirms or if the receiver has pre-approved the asset.
+
+:::note
+The `transfer_asset` function is designed for Account ID to Account ID transfers only. For transfers involving portfolios, first move the balance to an Account ID using `portfolio::move_portfolio_funds` or alternatively use the full settlement instruction flow shown above.
+:::
+
+```mermaid
+sequenceDiagram
+participant S as Asset Sender<br>(Account ID)
+participant R as Asset Receiver<br>(Account ID)
+participant P as Polymesh
+
+S ->> P: Call transfer_asset with:
+Note over S,P: Receiver Account ID, Asset ID, Amount, optional memo
+
+par
+  P ->> P: Resolve sender and receiver DIDs<br>from Account IDs
+  P ->> P: Create settlement instruction<br>with single leg
+and
+  P ->> P: Auto-affirm sender<br>Lock sender assets
+end
+
+alt Receiver has pre-approved the asset
+  P ->> P: Auto-execute instruction<br>Transfer assets immediately
+  P -->> S: Transfer complete
+  P -->> R: Assets received
+else Receiver has NOT pre-approved
+  P -->> R: Pending affirmation required
+  Note over S,P: Instruction awaits receiver affirmation
+
+  alt Receiver affirms
+    R ->> P: Call receiver_affirm_asset_transfer
+    P ->> P: Affirm receiver and<br>attempt execution
+    P ->> P: Transfer assets
+    P -->> S: Transfer complete
+    P -->> R: Assets received
+  else Receiver rejects
+    R ->> P: Call reject_asset_transfer
+    P ->> P: Release sender lock
+    P -->> S: Transfer rejected
+  end
+end
 ```

--- a/docs/200-core-concepts/080-portfolios/custody.md
+++ b/docs/200-core-concepts/080-portfolios/custody.md
@@ -23,6 +23,7 @@ When control of a portfolio is assigned, the custodian can:
 **Restrictions:**
 
 - The default portfolio cannot have a custodian. A custodian must be assigned to a user portfolio.
+- Account ID based portfolios (`PortfolioKind::AccountId`) cannot be placed under custody.
 - The custodian cannot move assets to portfolios under a different DID; only between portfolios of the same owner.
 - The custodian cannot delete the portfolio.
 - The custodian cannot rename the portfolio.

--- a/docs/200-core-concepts/080-portfolios/index.mdx
+++ b/docs/200-core-concepts/080-portfolios/index.mdx
@@ -11,7 +11,9 @@ tags:
 
 ## Overview
 
-In Polymesh, all [assets](/core/assets) (excluding the network native token [POLYX](/polyx)) are held at the [identity](/identity) level, or more correctly in Portfolios associated with an identity. This allows Polymesh to enforce [compliance](/compliance) in real time based on claims also held at the identity level.
+In Polymesh, all [assets](/core/assets) (excluding the network native token [POLYX](/polyx)) are held at the [identity](/identity) level, most commonly in portfolios associated with an identity. This allows Polymesh to enforce [compliance](/compliance) in real time based on claims also held at the identity level.
+
+Starting in v7.4.0, assets can also be held directly by signing keys using `PortfolioKind::AccountId`. This is additive to the portfolio model, which remains the default for most asset workflows.
 
 Portfolios allow users to organize their assets underneath their identity, and to flexibly assign key permissions and custody. A particular asset can have different balances across portfolios within the same identity.
 
@@ -87,6 +89,17 @@ graph TD
     P3 --> A5
     P4 --> A6
 ```
+
+## Account ID Balances (PortfolioKind::AccountId)
+
+Account ID balances let a signing key hold assets directly using `PortfolioKind::AccountId`. This is useful for simplified transfers to an Account ID without pre-fetching a DID and for workflows that do not require advanced portfolio features.
+
+Key points:
+
+- The balance is associated with a signing key, but compliance still applies based on the key's DID.
+- The settlement engine is still used for transfers, typically between default portfolios derived from DIDs.
+- Account ID portfolios do not support custody
+- Account ID portfolios are not supported by portfolio-level secondary-key permissions.
 
 ## Managing Portfolios
 


### PR DESCRIPTION
Introduce documentation for account ID based asset transfers, detailing the new features and restrictions associated with `PortfolioKind::AccountId`. 

This update also clarifies agent permissions during ownership transfers and outlines the implications for asset management and compliance.